### PR TITLE
Optionally skip fallback TTS init

### DIFF
--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -273,6 +273,10 @@ class PlaybackService(Thread):
                        'tts': self.tts.__class__.__name__})
 
     def _maybe_reload_tts(self):
+        """
+        Load TTS modules if not yet loaded or if configuration has changed.
+        Optionally pre-loads fallback TTS if configured
+        """
         config = self.config.get("tts", {})
 
         # update TTS object if configuration has changed
@@ -288,6 +292,9 @@ class PlaybackService(Thread):
 
         # if fallback TTS is the same as main TTS dont load it
         if config.get("module", "") == config.get("fallback_module", ""):
+            return
+
+        if not config.get('preload_fallback', True):
             return
 
         if not self._fallback_tts_hash or \

--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -295,6 +295,7 @@ class PlaybackService(Thread):
             return
 
         if not config.get('preload_fallback', True):
+            LOG.debug("Skipping fallback TTS init")
             return
 
         if not self._fallback_tts_hash or \


### PR DESCRIPTION
Add a config option to skip Fallback TTS init with module init
Fallback TTS will be loaded on first call, so this speeds up module init and memory use at the expense of potentially slower responses if fallback is reached