### PR TITLE
Fix config not passed to setup_audio_service

### DIFF
--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -92,7 +92,7 @@ class AudioService:
         remote = []
         for plugin_name, plugin_module in found_plugins.items():
             LOG.info(f'Loading audio service plugin: {plugin_name}')
-            s = setup_audio_service(plugin_module, bus=self.bus)
+            s = setup_audio_service(plugin_module, config=self.config, bus=self.bus)
             if not s:
                 continue
             if isinstance(s, RemoteAudioBackend):


### PR DESCRIPTION
This change fixes a problem with setup_audio_service not having the right config dictionary when initializing ovos-audio plugins. If no config is passed, setup_audio_service uses `Configuration()`, which is the whole configuration object, not the  audio-specific config. This resulted in no audio service being loaded, making ovos unable to speak.
https://github.com/OpenVoiceOS/ovos-plugin-manager/blob/dev/ovos_plugin_manager/audio.py#L53C39-L53C39
This line may also need to be fixed, but because I'm not familiar with the codebase, I wasn't sure which method would be the best to use here.