### PR TITLE
Updated logging in PlaybackThread queue handling

### DIFF
--- a/ovos_audio/playback.py
+++ b/ovos_audio/playback.py
@@ -222,8 +222,10 @@ class PlaybackThread(Thread):
 
                 self._now_playing = (data, visemes, listen, tts_id, message)
                 self._play()
+            except Empty:
+                pass
             except Exception as e:
-                LOG.debug(e)
+                LOG.error(e)
 
     def show_visemes(self, pairs):
         """Send viseme data to enclosure


### PR DESCRIPTION
Prevent empty logging of `queue.Empty` exceptions
Update exceptions to log error instead of DEBUG since empty queue is explicitly handled