### PR TITLE
fix - 3 second delay on listen sound

### DIFF
--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -475,13 +475,14 @@ class PlaybackService(Thread):
             audio_file = self._path_from_hexdata(hex_audio, audio_ext)
         if not audio_file:
             raise ValueError(f"message.data needs to provide 'uri' or 'binary_data': {message.data}")
+
         audio_file = self._resolve_sound_uri(audio_file)
 
         # volume handling and audio service ducking
         ensure_volume = message.data.get("force_unmute", False)
         duck_pulse_handled = bool(self.tts and self.tts.config.get("pulse_duck"))
         if ensure_volume:
-            volume_poll: Message = self.bus.wait_for_response(Message("mycroft.volume.get"))
+            volume_poll: Message = self.bus.wait_for_response(Message("mycroft.volume.get"), timeout=0.3)
             volume = volume_poll.data.get("percent", 0) if volume_poll else 80
             muted = volume_poll.data.get("muted", False) if volume_poll else False
             volume_changed = False

--- a/ovos_audio/utils.py
+++ b/ovos_audio/utils.py
@@ -76,8 +76,4 @@ def stop_speaking():
 
 
 def report_timing(ident, stopwatch, data):
-    try:
-        from mycroft.metrics import report_timing
-        report_timing(ident, 'speech', stopwatch, data)
-    except:
-        LOG.error("Failed to upload metrics")
+    """ TODO - implement metrics upload at some point """

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,4 +1,4 @@
-ovos_plugin_common_play~=0.0, >=0.0.6a2
+ovos_plugin_common_play~=0.0, >=0.0.6a11
 
 ovos-tts-plugin-server
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,5 @@
-ovos-utils~=0.0, >=0.0.37
-ovos-bus-client~=0.0, >=0.0.7
+ovos-utils~=0.0, >=0.0.38
+ovos-bus-client~=0.0, >=0.0.8
 ovos-config~=0.0,>=0.0.12
-ovos-plugin-manager~=0.0, >=0.0.24
+ovos-plugin-manager~=0.0, >=0.0.25
 


### PR DESCRIPTION
if alsa plugin is not present to answer the mute/unmute messages there was a  3 second timeout

this makes it tolerable

removes a old kludge for mycroft metrics to avoid log spam around the deprecated mycroft import