### PR TITLE
refactor/drop audio service

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 The "mouth" of the OVOS assistant!
 
-Handles TTS generation and audio playback
+Handles TTS generation and sounds playback
 
 ## Install
 
@@ -51,27 +51,6 @@ under mycroft.conf
 
   // Mechanism used to play OGG audio files
   // Override: SYSTEM
-  "play_ogg_cmdline": "ogg123 -q %1",
-  
-  "Audio": {
-    // message.context may contains a source and destination
-    // native audio (playback / TTS) will only be played if a
-    // message destination is a native_source or if missing (considered a broadcast)
-    "native_sources": ["debug_cli", "audio"],
-
-    "backends": {
-      "OCP": {
-        "type": "ovos_common_play",
-        "active": true
-      },
-      "simple": {
-        "type": "ovos_audio_simple",
-        "active": true
-      },
-      "vlc": {
-        "type": "ovos_vlc",
-        "active": true
-      }
-  }
+  "play_ogg_cmdline": "ogg123 -q %1"
 }
 ```

--- a/ovos_audio/utils.py
+++ b/ovos_audio/utils.py
@@ -14,10 +14,11 @@
 #
 import time
 
+from ovos_utils.log import deprecated
+from ovos_utils.signal import check_for_signal
+
 from ovos_bus_client.send_func import send
 from ovos_config import Configuration
-from ovos_utils.log import LOG, deprecated
-from ovos_utils.signal import check_for_signal
 
 
 def validate_message_context(message, native_sources=None):

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,9 +1,1 @@
-ovos_plugin_common_play~=0.0, >=0.0.6a11
-
 ovos-tts-plugin-server
-
-# ovos-ocp-youtube-plugin
-ovos-ocp-m3u-plugin
-ovos-ocp-rss-plugin
-ovos-ocp-files-plugin
-ovos-ocp-news-plugin

--- a/test/unittests/test_speech.py
+++ b/test/unittests/test_speech.py
@@ -286,15 +286,8 @@ class TestSpeech(unittest.TestCase):
 
         speech.handle_opm_g2p_query(Message("opm.g2p.query"))
 
-    @mock.patch('ovos_audio.service.get_audio_service_configs')
-    def test_opm_audio(self, mock_get_configs, tts_factory_mock, config_mock):
+    def test_opm_audio(self, tts_factory_mock, config_mock):
         setup_mocks(config_mock, tts_factory_mock)
-
-        ocp = {"type": "ovos_common_play", "active": True}
-        p = {"type": "ovos_badass_player", "active": True}
-
-        # per module configs, mocking same return val for all plugin inputs (!)
-        mock_get_configs.return_value = {"ocp": ocp, "badass": p}
 
         bus = FakeBus()
         speech = PlaybackService(bus=bus)
@@ -302,11 +295,8 @@ class TestSpeech(unittest.TestCase):
         def rcvm(msg):
             msg = json.loads(msg)
             self.assertEqual(msg["type"], "opm.audio.query.response")
-            self.assertEqual(msg["data"]["plugins"], ["ocp", "badass"])
-            self.assertEqual(msg["data"]["configs"], {"ocp": ocp, "badass": p})
-            ocp["plugin_name"] = 'Ovos Common Play'
-            p["plugin_name"] = 'Ovos Badass Player'
-            self.assertEqual(msg["data"]["options"], [ocp, p])
+            self.assertEqual(msg["data"]["plugins"], [])
+            self.assertEqual(msg["data"]["configs"], {})
 
         bus.on("message", rcvm)
 


### PR DESCRIPTION
migration to [ovos-media](https://github.com/OpenVoiceOS/ovos-media) as companion service

allows disabling the native audio service via config, and logs a warning about doing it

new config option, once ovos-media is widely adopted should be changed to false in ovos-config mycroft.conf
```
"enable_old_audioservice": true
```