### PR TITLE
fix/tts_reload

### DIFF
--- a/test/unittests/test_speech.py
+++ b/test/unittests/test_speech.py
@@ -149,6 +149,7 @@ class TestSpeech(unittest.TestCase):
 
         speech = PlaybackService(bus=bus)
         speech.tts = FailingTTS()
+        speech._tts_hash = "123failing"
 
         speech.execute_tts("hello", "123")
         self.assertTrue(speech.fallback_tts.execute.called)


### PR DESCRIPTION
TTS reload was only working for plugin changes

the check for config changes only accounted for module, not for the whole config, so changing voice etc would require a reload

closes https://github.com/OpenVoiceOS/ovos-audio/issues/19  (i think?)

related fix https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/219