### PR TITLE
feat/b64_tts

### DIFF
--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -256,7 +256,7 @@ class PlaybackService(Thread):
             self.status.set_error('No TTS loaded')
 
     def handle_b64_audio(self, message):
-        """syntehsizes speech, but instead of queuing for playback
+        """synthesizes speech, but instead of queuing for playback
         returns it b64 encoded in the bus
         allows 3rd party integrations to use OVOS as a TTS service
         """

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,5 +1,4 @@
 ovos-utils~=0.0, >=0.0.38
 ovos-bus-client~=0.0, >=0.0.8
 ovos-config~=0.0,>=0.0.13a7
-ovos-plugin-manager~=0.0, >=0.0.25
-
+ovos-plugin-manager~=0.0, >=0.0.26a16


### PR DESCRIPTION
feat/b64_tts

A hivemind satellite can listen for `speak` messages from master, reply with ` speak:b64_audio` , and listen for ` speak:b64_audio.response`  containing b64 encoded audio to play. eg, in a browser

counterpart to https://github.com/OpenVoiceOS/ovos-dinkum-listener/pull/75

needs https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/195 