### PR TITLE
refactor/legacy_audio ocp state events

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -50,7 +50,7 @@ jobs:
           python -m pip install build wheel
       - name: Install repo
         run: |
-          pip install .
+          pip install . --pre
       - name: Install test dependencies
         run: |
           pip install -r test/requirements.txt

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Install System Dependencies
         run: |
           sudo apt-get update
-          sudo apt install python3-dev swig
+          sudo apt install python3-dev swig sox mpg123
           python -m pip install build wheel
       - name: Install repo
         run: |

--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -50,7 +50,7 @@ jobs:
           python -m pip install build wheel
       - name: Install repo
         run: |
-          pip install . --pre
+          pip install .
       - name: Install test dependencies
         run: |
           pip install -r test/requirements.txt

--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -20,11 +20,44 @@ from ovos_plugin_manager.templates.audio import RemoteAudioBackend
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import MonotonicEvent
 from ovos_audio.utils import validate_message_context
-from ovos_utils.ocp import MediaState
+
 try:
     from ovos_plugin_common_play import OCPAudioBackend
 except ImportError:
     OCPAudioBackend = None
+
+try:
+    from ovos_utils.ocp import MediaState
+except ImportError:
+    LOG.warning("Please update to ovos-utils~=0.1.")
+    from enum import IntEnum
+
+
+    class MediaState(IntEnum):
+        # https://doc.qt.io/qt-5/qmediaplayer.html#MediaStatus-enum
+        # The status of the media cannot be determined.
+        UNKNOWN = 0
+        # There is no current media. PlayerState == STOPPED
+        NO_MEDIA = 1
+        # The current media is being loaded. The player may be in any state.
+        LOADING_MEDIA = 2
+        # The current media has been loaded. PlayerState== STOPPED
+        LOADED_MEDIA = 3
+        # Playback of the current media has stalled due to
+        # insufficient buffering or some other temporary interruption.
+        # PlayerState != STOPPED
+        STALLED_MEDIA = 4
+        # The player is buffering data but has enough data buffered
+        # for playback to continue for the immediate future.
+        # PlayerState != STOPPED
+        BUFFERING_MEDIA = 5
+        # The player has fully buffered the current media. PlayerState != STOPPED
+        BUFFERED_MEDIA = 6
+        # Playback has reached the end of the current media. PlayerState == STOPPED
+        END_OF_MEDIA = 7
+        # The current media cannot be played. PlayerState == STOPPED
+        INVALID_MEDIA = 8
+
 
 MINUTES = 60  # Seconds in a minute
 

--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -128,7 +128,7 @@ class AudioService:
             LOG.info(f'Found audio service plugin: {plugin_name}')
             s = setup_audio_service(plugin_module, config=self.config, bus=self.bus)
             if not s:
-                LOG.info(f"{plugin_name} not loaded! config: {self.config}")
+                LOG.debug(f"{plugin_name} not loaded! config: {self.config}")
                 continue
             if isinstance(s, RemoteAudioBackend):
                 remote += s

--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -1,1 +1,2 @@
 ovos-tts-plugin-server
+ovos_audio_plugin_simple>=0.0.2a7

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 ovos-utils~=0.0, >=0.0.38
 ovos-bus-client~=0.0, >=0.0.8
 ovos-config~=0.0,>=0.0.13a7
-ovos-plugin-manager~=0.0, >=0.0.26a16
+ovos-plugin-manager~=0.0, >=0.0.26a21

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 ovos-utils~=0.0, >=0.0.38
 ovos-bus-client~=0.0, >=0.0.8
 ovos-config~=0.0,>=0.0.13a7
-ovos-plugin-manager~=0.0, >=0.0.26a21
+ovos-plugin-manager~=0.0, >=0.0.26a22

--- a/test/requirements.txt
+++ b/test/requirements.txt
@@ -3,7 +3,5 @@ flake8==3.7.9
 pytest==5.2.4
 pytest-cov==2.8.1
 cov-core==1.15.0
-sphinx==2.2.1
-sphinx-rtd-theme==0.4.3
-ovos-audio-plugin-simple~=0.0.1
-ovos-plugin-vlc~=0.0.1
+ovos_audio_plugin_simple>=0.0.2a7
+ovos-utils>=0.1.0a16

--- a/test/unittests/test_end2end.py
+++ b/test/unittests/test_end2end.py
@@ -10,18 +10,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-import unittest
-import unittest.mock as mock
 import time
-from shutil import rmtree
-from threading import Thread
+import unittest
 from time import sleep
 
-from os.path import exists
-from ovos_utils.fakebus import FakeBus
-from ovos_audio.service import AudioService
 from ovos_bus_client.message import Message
-from ovos_utils.ocp import MediaState
+from ovos_utils.fakebus import FakeBus
+from ovos_utils.ocp import MediaState, TrackState, PlayerState
+
+from ovos_audio.service import AudioService
 
 
 class TestLegacy(unittest.TestCase):
@@ -29,6 +26,61 @@ class TestLegacy(unittest.TestCase):
         self.core = AudioService(FakeBus(), disable_ocp=True, autoload=False)
         self.core.config['default-backend'] = "simple"
         self.core.load_services()
+        # simple plugin
+        self.core.bus.remove_all_listeners('ovos.common_play.simple.play')
+
+    def test_http(self):
+
+        messages = []
+
+        def new_msg(msg):
+            nonlocal messages
+            m = Message.deserialize(msg)
+            messages.append(m)
+            print(len(messages), msg)
+
+        def wait_for_n_messages(n):
+            nonlocal messages
+            t = time.time()
+            while len(messages) < n:
+                sleep(0.1)
+                if time.time() - t > 10:
+                    raise RuntimeError("did not get the number of expected messages under 10 seconds")
+
+        self.core.bus.on("message", new_msg)
+
+        utt = Message('mycroft.audio.service.play',
+                      {"tracks": ["http://fake.mp3"]},
+                      {})
+        self.core.bus.emit(utt)
+
+        # confirm all expected messages are sent
+        expected_messages = [
+            'mycroft.audio.service.play',
+            "ovos.common_play.media.state",  # LOADED_MEDIA
+            "ovos.common_play.track.state",  # QUEUED_AUDIOSERVICE
+            "ovos.common_play.simple.play",  # call simple plugin
+            "ovos.common_play.player.state",  # PLAYING
+            "ovos.common_play.media.state",  # LOADED_MEDIA
+            "ovos.common_play.track.state",  # PLAYING_AUDIOSERVICE
+        ]
+        wait_for_n_messages(len(expected_messages))
+
+        self.assertEqual(len(expected_messages), len(messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+        state = messages[1]
+        self.assertEqual(state.data["state"], MediaState.LOADED_MEDIA)
+        state = messages[2]
+        self.assertEqual(state.data["state"], TrackState.QUEUED_AUDIOSERVICE)
+        state = messages[4]
+        self.assertEqual(state.data["state"], PlayerState.PLAYING)
+        state = messages[5]
+        self.assertEqual(state.data["state"], MediaState.LOADED_MEDIA)
+        state = messages[6]
+        self.assertEqual(state.data["state"], TrackState.PLAYING_AUDIOSERVICE)
 
     def test_uri_error(self):
 
@@ -69,6 +121,162 @@ class TestLegacy(unittest.TestCase):
 
         state = messages[-1]
         self.assertEqual(state.data["state"], MediaState.INVALID_MEDIA)
+
+    def test_PLAYLIST(self):
+
+        messages = []
+
+        def new_msg(msg):
+            nonlocal messages
+            m = Message.deserialize(msg)
+            messages.append(m)
+            print(len(messages), msg)
+
+        def wait_for_n_messages(n):
+            nonlocal messages
+            t = time.time()
+            while len(messages) < n:
+                sleep(0.1)
+                if time.time() - t > 10:
+                    raise RuntimeError("did not get the number of expected messages under 10 seconds")
+
+        self.core.bus.on("message", new_msg)
+
+        utt = Message('mycroft.audio.service.play',
+                      {"tracks": ["http://fake.mp3",
+                                  "http://fake2.mp3",
+                                  "http://fake3.mp3"]},
+                      {})
+        self.core.bus.emit(utt)
+
+        # confirm all expected messages are sent
+        expected_messages = [
+            'mycroft.audio.service.play',
+            "ovos.common_play.media.state",  # LOADED_MEDIA
+            "ovos.common_play.track.state",  # QUEUED_AUDIOSERVICE
+            "ovos.common_play.simple.play",  # call simple plugin
+            "ovos.common_play.player.state",  # PLAYING
+            "ovos.common_play.media.state",  # LOADED_MEDIA
+            "ovos.common_play.track.state",  # PLAYING_AUDIOSERVICE
+        ]
+        wait_for_n_messages(len(expected_messages))
+
+        self.assertEqual(len(expected_messages), len(messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+        self.assertEqual(self.core.default._tracks,
+                         ['http://fake.mp3',
+                          'http://fake2.mp3',
+                          'http://fake3.mp3'])
+        self.assertEqual(self.core.default._idx, 0)
+
+        messages = []
+
+        utt = Message('mycroft.audio.service.next',
+                      {},
+                      {})
+        self.core.bus.emit(utt)
+
+        # confirm all expected messages are sent
+        expected_messages = [
+            'mycroft.audio.service.next',
+            "ovos.common_play.media.state",  # LOADED_MEDIA
+            "ovos.common_play.track.state",  # QUEUED_AUDIOSERVICE
+            "ovos.common_play.simple.play",  # call simple plugin
+        ]
+        wait_for_n_messages(len(expected_messages))
+
+        self.assertEqual(len(expected_messages), len(messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+        self.assertEqual(self.core.default._tracks,
+                         ['http://fake.mp3',
+                          'http://fake2.mp3',
+                          'http://fake3.mp3'])
+        self.assertEqual(self.core.default._idx, 1)
+        messages = []
+
+        utt = Message('mycroft.audio.service.next',
+                      {},
+                      {})
+        self.core.bus.emit(utt)
+
+        # confirm all expected messages are sent
+        expected_messages = [
+            'mycroft.audio.service.next',
+            "ovos.common_play.media.state",  # LOADED_MEDIA
+            "ovos.common_play.track.state",  # QUEUED_AUDIOSERVICE
+            "ovos.common_play.simple.play",  # call simple plugin
+        ]
+        wait_for_n_messages(len(expected_messages))
+
+        self.assertEqual(len(expected_messages), len(messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+        self.assertEqual(self.core.default._tracks,
+                         ['http://fake.mp3',
+                          'http://fake2.mp3',
+                          'http://fake3.mp3'])
+        self.assertEqual(self.core.default._idx, 2)
+        messages = []
+
+        utt = Message('mycroft.audio.service.prev',
+                      {},
+                      {})
+        self.core.bus.emit(utt)
+
+        # confirm all expected messages are sent
+        expected_messages = [
+            'mycroft.audio.service.prev',
+            "ovos.common_play.media.state",  # LOADED_MEDIA
+            "ovos.common_play.track.state",  # QUEUED_AUDIOSERVICE
+            "ovos.common_play.simple.play",  # call simple plugin
+        ]
+        wait_for_n_messages(len(expected_messages))
+
+        self.assertEqual(len(expected_messages), len(messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+        self.assertEqual(self.core.default._tracks,
+                         ['http://fake.mp3',
+                          'http://fake2.mp3',
+                          'http://fake3.mp3'])
+        self.assertEqual(self.core.default._idx, 1)
+
+        messages = []
+
+        # TODO - need OPM bugfix to pass
+        utt = Message('mycroft.audio.service.queue',
+                      {"tracks": ['http://fake4.mp3', 'http://fake5.mp3']},
+                      {})
+        self.core.bus.emit(utt)
+
+        # confirm all expected messages are sent
+        expected_messages = [
+            'mycroft.audio.service.queue'
+        ]
+        wait_for_n_messages(len(expected_messages))
+
+        self.assertEqual(len(expected_messages), len(messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+        self.assertEqual(self.core.default._tracks,
+                         ['http://fake.mp3',
+                          'http://fake2.mp3',
+                          'http://fake3.mp3',
+                          'http://fake4.mp3',
+                          'http://fake5.mp3'])
+        self.assertEqual(self.core.default._idx, 1)
 
 
 if __name__ == "__main__":

--- a/test/unittests/test_end2end.py
+++ b/test/unittests/test_end2end.py
@@ -1,0 +1,75 @@
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+import unittest
+import unittest.mock as mock
+import time
+from shutil import rmtree
+from threading import Thread
+from time import sleep
+
+from os.path import exists
+from ovos_utils.fakebus import FakeBus
+from ovos_audio.service import AudioService
+from ovos_bus_client.message import Message
+from ovos_utils.ocp import MediaState
+
+
+class TestLegacy(unittest.TestCase):
+    def setUp(self):
+        self.core = AudioService(FakeBus(), disable_ocp=True, autoload=False)
+        self.core.config['default-backend'] = "simple"
+        self.core.load_services()
+
+    def test_uri_error(self):
+
+        messages = []
+
+        def new_msg(msg):
+            nonlocal messages
+            m = Message.deserialize(msg)
+            messages.append(m)
+            print(len(messages), msg)
+
+        def wait_for_n_messages(n):
+            nonlocal messages
+            t = time.time()
+            while len(messages) < n:
+                sleep(0.1)
+                if time.time() - t > 10:
+                    raise RuntimeError("did not get the number of expected messages under 10 seconds")
+
+        self.core.bus.on("message", new_msg)
+
+        utt = Message('mycroft.audio.service.play',
+                      {"tracks": ["bad_uri://fake.mp3"]},
+                      {})
+        self.core.bus.emit(utt)
+
+        # confirm all expected messages are sent
+        expected_messages = [
+            'mycroft.audio.service.play',
+            "ovos.common_play.media.state"  # invalid media
+        ]
+        wait_for_n_messages(len(expected_messages))
+
+        self.assertEqual(len(expected_messages), len(messages))
+
+        for idx, m in enumerate(messages):
+            self.assertEqual(m.msg_type, expected_messages[idx])
+
+        state = messages[-1]
+        self.assertEqual(state.data["state"], MediaState.INVALID_MEDIA)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test/unittests/test_end2end.py
+++ b/test/unittests/test_end2end.py
@@ -57,7 +57,7 @@ class TestLegacy(unittest.TestCase):
         # confirm all expected messages are sent
         expected_messages = [
             'mycroft.audio.service.play',
-            "ovos.common_play.media.state",  # LOADED_MEDIA
+            "ovos.common_play.media.state",  # LOADING_MEDIA
             "ovos.common_play.track.state",  # QUEUED_AUDIOSERVICE
             "ovos.common_play.simple.play",  # call simple plugin
             "ovos.common_play.player.state",  # PLAYING
@@ -72,7 +72,7 @@ class TestLegacy(unittest.TestCase):
             self.assertEqual(m.msg_type, expected_messages[idx])
 
         state = messages[1]
-        self.assertEqual(state.data["state"], MediaState.LOADED_MEDIA)
+        self.assertEqual(state.data["state"], MediaState.LOADING_MEDIA)
         state = messages[2]
         self.assertEqual(state.data["state"], TrackState.QUEUED_AUDIOSERVICE)
         state = messages[4]

--- a/test/unittests/test_end2end.py
+++ b/test/unittests/test_end2end.py
@@ -25,6 +25,10 @@ class TestLegacy(unittest.TestCase):
     def setUp(self):
         self.core = AudioService(FakeBus(), disable_ocp=True, autoload=False)
         self.core.config['default-backend'] = "simple"
+        self.core.config['backends'] = {"simple": {
+            "type": "ovos_simple",
+            "active": True
+        }}
         self.core.load_services()
         # simple plugin
         self.core.bus.remove_all_listeners('ovos.common_play.simple.play')


### PR DESCRIPTION
ensures OCP player state events are emitted by the legacy subsystem

needs: https://github.com/OpenVoiceOS/ovos-plugin-manager/pull/226