### PR TITLE
fix/ducking

### DIFF
--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -303,7 +303,7 @@ class AudioService:
         """
         if not self._is_message_for_service(message):
             return
-        if self.current:
+        if self.current and self.volume_is_low:
             LOG.debug('lowering volume')
             self.current.lower_volume()
             self.volume_is_low = True
@@ -312,11 +312,10 @@ class AudioService:
         """Triggered when mycroft is done speaking and restores the volume."""
         if not self._is_message_for_service(message):
             return
-        current = self.current
-        if current:
+        if self.current and not self.volume_is_low:
             LOG.debug('restoring volume')
             self.volume_is_low = False
-            current.restore_volume()
+            self.current.restore_volume()
 
     def _restore_volume_after_record(self, message=None):
         """
@@ -331,8 +330,9 @@ class AudioService:
             return
 
         def restore_volume(msg=message):
-            LOG.debug('restoring volume')
-            self.current.restore_volume()
+            if self.volume_is_low:
+                LOG.debug('restoring volume')
+                self.current.restore_volume()
 
         if self.current:
             self.bus.on('recognizer_loop:speech.recognition.unknown',

--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -303,7 +303,7 @@ class AudioService:
         """
         if not self._is_message_for_service(message):
             return
-        if self.current and self.volume_is_low:
+        if self.current and not self.volume_is_low:
             LOG.debug('lowering volume')
             self.current.lower_volume()
             self.volume_is_low = True
@@ -312,7 +312,7 @@ class AudioService:
         """Triggered when mycroft is done speaking and restores the volume."""
         if not self._is_message_for_service(message):
             return
-        if self.current and not self.volume_is_low:
+        if self.current and self.volume_is_low:
             LOG.debug('restoring volume')
             self.volume_is_low = False
             self.current.restore_volume()


### PR DESCRIPTION
self.volume_is_low variable was ignored

restore/lower_volume could be called multiple times, getting audio plugins off track

eg, by calling lower_volume twice it can cause vlc plugin to loose track of normal volume https://github.com/OpenVoiceOS/ovos-plugin-vlc/blob/dev/ovos_plugin_vlc/__init__.py#L106