### PR TITLE
fix/ducking

### DIFF
--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -530,16 +530,7 @@ class PlaybackService(Thread):
             elif muted:
                 self.bus.emit(Message("mycroft.volume.unmute"))
 
-        if self.audio:
-            if self.audio.current and not duck_pulse_handled:
-                self.audio.current.lower_volume()
-
         play_audio(audio_file).wait()
-
-        # return to previous state
-        if self.audio:
-            if self.audio.current and not duck_pulse_handled:
-                self.audio.current.restore_volume()
 
         if ensure_volume:
             if volume_changed:


### PR DESCRIPTION
when playing sounds it was ALSO ducking volume causing issues, with this PR the (second) ducking on play_sound is removed 

the problem with 2 audio duckings was that the normal_volume was overwritten, so volume was never restored

companion to https://github.com/OpenVoiceOS/ovos-plugin-vlc/pull/10