### PR TITLE
fix/ducking again

### DIFF
--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -282,6 +282,10 @@ class AudioService:
                                   {"by": "audio:" + name})
                 self.bus.emit(msg)
 
+            # ensure we don't leave the volume ducked
+            self.current.restore_volume()
+            self.volume_is_low = False
+
         self.current = None
 
     @require_native_source()


### PR DESCRIPTION
when stopping a audio service self.current is set to None, we lose the reference and are unable to restore volume because of that (race condition)

ensure that when we stop a audio service we restore the default volume

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Restored volume and reset playback flag when stopping audio to ensure consistent audio experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->