### PR TITLE
fix/drop_OCP_mycroft_hacks

### DIFF
--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -90,6 +90,11 @@ class AudioService:
             self.load_services()
 
     def find_ocp(self):
+        if self.disable_ocp:
+            LOG.info("classic OCP is disabled in config, OCP bus api not available!")
+            # NOTE: ovos-core should detect this and use the classic audio service api automatically
+            return
+
         try:
             from ovos_plugin_common_play import OCPAudioBackend
         except ImportError:

--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -74,6 +74,7 @@ class AudioService:
         self.service_lock = Lock()
 
         self.default = None
+        self.ocp = None
         self.service = []
         self.current = None
         self.play_start_time = 0
@@ -94,7 +95,8 @@ class AudioService:
         except ImportError:
             LOG.debug("classic OCP not installed")
             return False
-        ocp_config = Configuration().get("Audio", {}).get("OCP", {})
+        # config from legacy location in default mycroft.conf
+        ocp_config = Configuration().get("Audio", {}).get("backends", {}).get("OCP", {})
         self.ocp = OCPAudioBackend(ocp_config, bus=self.bus)
         try:
             self.ocp.player.validate_source = self.validate_source
@@ -148,6 +150,12 @@ class AudioService:
         for s in self.service:
             s.set_track_start_callback(self.track_start)
 
+        # load OCP
+        # NOTE: this will be replace by ovos-media in a future release
+        # and can be disabled in config
+        self.find_ocp()
+
+        # load audio playback plugins (vlc, mpv, spotify ...)
         self.find_default()
 
         # Setup event handlers

--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -106,8 +106,9 @@ class AudioService:
         try:
             self.ocp.player.validate_source = self.validate_source
             self.ocp.player.native_sources = self.native_sources
-        except:
-            pass  # handle older OCP plugin versions
+        except Exception as e:
+            # handle older OCP plugin versions
+            LOG.warning("old OCP version detected! please update 'ovos_plugin_common_play'")
 
     def find_default(self):
         if not self.service:


### PR DESCRIPTION
OCP was loaded as a regular audio plugin, this was the only way to inject it into mycroft-core

in OVOS this is no longer needed and OCP is loaded directly as part of ovos-audio (until ovos-media is released)

the compat layer is dropped to avoid issues in edge cases, such as it getting selected as the default audio plugin if no others are installed, which can cause an infinite loop at playback time

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Simplified audio backend setup by removing conditional logic related to `disable_ocp` flag.
  - Improved handling of older plugin versions for OCP backend.
  - Ensured default audio backend is always set up correctly.
  - Added event handlers for audio playback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->