### PR TITLE
fix:extras

### DIFF
--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -4,6 +4,8 @@ ovos-tts-plugin-server>=0.0.2, <1.0.0
 # Media Playback plugins
 ovos_audio_plugin_simple>=0.1.0, <1.0.0
 ovos-audio-plugin-mpv>=0.0.1, <1.0.0
+ovos-media-plugin-spotify>=0.2.3, <1.0.0
+ovos-media-plugin-chromecast>=0.1.0, <1.0.0
 ovos_plugin_common_play>=0.0.7, <1.0.0
 
 # OCP plugins


### PR DESCRIPTION
include spotify and chromecast plugins, this makes the cli scripts to set them up available by default