### PR TITLE
fix:extras_from_ocp

### DIFF
--- a/requirements/extras.txt
+++ b/requirements/extras.txt
@@ -6,11 +6,4 @@ ovos_audio_plugin_simple>=0.1.0, <1.0.0
 ovos-audio-plugin-mpv>=0.0.1, <1.0.0
 ovos-media-plugin-spotify>=0.2.3, <1.0.0
 ovos-media-plugin-chromecast>=0.1.0, <1.0.0
-ovos_plugin_common_play>=0.0.7, <1.0.0
-
-# OCP plugins
-ovos-ocp-youtube-plugin~=0.0, >=0.0.1
-ovos-ocp-m3u-plugin>=0.0.1,<1.0.0
-ovos-ocp-rss-plugin>=0.0.2,<1.0.0
-ovos-ocp-files-plugin~=0.13
-ovos-ocp-news-plugin>=0.0.3,<1.0.0
+ovos_plugin_common_play[extractors]>=0.0.7, <2.0.0


### PR DESCRIPTION
let OCP define default stream extractors

allow 1.X.X with mycroft compat removed https://github.com/OpenVoiceOS/ovos-ocp-audio-plugin/pull/132