### PR TITLE
refactor!:drop OCP

### DIFF
--- a/docs/drop-ocp.md
+++ b/docs/drop-ocp.md
@@ -1,0 +1,21 @@
+# Dropping the in-process OCP audio backend
+
+The legacy `AudioService` no longer loads OCP itself. The classic OCP audio backend
+(`ovos_plugin_common_play.OCPAudioBackend`) and everything that wired it in are removed:
+
+- `AudioService.find_ocp()`, the `self.ocp` attribute, and the `disable_ocp` flag /
+  constructor argument are gone.
+- The legacy `MediaState` import fallback is dropped — `ovos_utils.ocp.MediaState` is now
+  required directly.
+- `ovos_plugin_common_play` is removed from the requirements.
+
+`AudioService` is now strictly the legacy media-backend host (VLC, MPV, …) driven by the
+`mycroft.audio.service.*` bus API. It no longer owns OCP playback.
+
+## Spec conformance
+
+Aligns with **OVOS-OCP-1**. OCP search and playback move out of `ovos-audio`'s in-process
+audio service: discovery is handled by `MediaProvider` plugins
+(`opm.media.provider`, queried in-process by the OCP pipeline, replacing the old OCP search
+skills) rather than the bundled `OCPAudioBackend`. `ovos-audio` retains only TTS output and
+the legacy `mycroft.audio.service.*` backends.

--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -66,47 +66,29 @@ class AudioService:
         to be played.
     """
 
-    def __init__(self, bus, autoload=True, disable_ocp=False, validate_source=True):
+    def __init__(self, bus, autoload=True, validate_source=True, disable_ocp=None):
         """
             Args:
                 bus: Mycroft messagebus
+                disable_ocp: deprecated no-op. The classic OCP audio backend has
+                    been removed; media playback now lives in the OCP MediaProvider
+                    plugins / ovos-media (OVOS-OCP-1). Accepted for backward
+                    compatibility and ignored.
         """
         self.bus = bus
         self.config = Configuration().get("Audio") or {}
         self.service_lock = Lock()
 
         self.default = None
-        self.ocp = None
         self.service = []
         self.current = None
         self.play_start_time = 0
         self.volume_is_low = False
         self.volume_is_speaking = False
-        self.disable_ocp = disable_ocp
         self.validate_source = validate_source
         self._loaded = MonotonicEvent()
         if autoload:
             self.load_services()
-
-    def find_ocp(self):
-        if self.disable_ocp:
-            LOG.info("classic OCP is disabled in config, OCP bus api not available!")
-            # NOTE: ovos-core should detect this and use the classic audio service api automatically
-            return
-
-        try:
-            from ovos_plugin_common_play import OCPAudioBackend
-        except ImportError:
-            LOG.debug("classic OCP not installed")
-            return False
-        # config from legacy location in default mycroft.conf
-        ocp_config = Configuration().get("Audio", {}).get("backends", {}).get("OCP", {})
-        self.ocp = OCPAudioBackend(ocp_config, bus=self.bus)
-        try:
-            self.ocp.player.validate_source = self.validate_source
-        except Exception as e:
-            # handle older OCP plugin versions
-            LOG.warning("old OCP version detected! please update 'ovos_plugin_common_play'")
 
     def find_default(self):
         if not self.service:
@@ -153,11 +135,6 @@ class AudioService:
         # Register end of track callback
         for s in self.service:
             s.set_track_start_callback(self.track_start)
-
-        # load OCP
-        # NOTE: this will be replace by ovos-media in a future release
-        # and can be disabled in config
-        self.find_ocp()
 
         # load audio playback plugins (vlc, mpv, spotify ...)
         self.find_default()

--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -55,9 +55,13 @@ class PlaybackService(Thread):
     def __init__(self, ready_hook=on_ready, error_hook=on_error,
                  stopping_hook=on_stopping, alive_hook=on_alive,
                  started_hook=on_started, watchdog=lambda: None,
-                 bus=None, disable_ocp=None, validate_source=True,
+                 bus=None, validate_source=True,
                  tts: Optional[TTS] = None,
-                 disable_fallback: bool = False):
+                 disable_fallback: bool = False,
+                 disable_ocp=None):
+        # disable_ocp: deprecated no-op — the classic OCP audio backend has been
+        # removed; media playback moved to the OCP MediaProvider plugins /
+        # ovos-media (OVOS-OCP-1). Accepted for backward compatibility and ignored.
         super(PlaybackService, self).__init__()
 
         LOG.info("Starting Audio Service")
@@ -102,14 +106,10 @@ class PlaybackService(Thread):
 
         self.audio = None
         self.audio_enabled = self.config.get("enable_old_audioservice", True)  # TODO default to False soon
-        if disable_ocp is None:
-            disable_ocp = self.config.get("disable_ocp", False)  # TODO default to True soon
-        self.disable_ocp = disable_ocp
         LOG.debug(f"legacy audio service enabled: {self.audio_enabled}")
         if self.audio_enabled:
             try:
-                self.audio = AudioService(self.bus, disable_ocp=disable_ocp,
-                                          validate_source=validate_source)
+                self.audio = AudioService(self.bus, validate_source=validate_source)
             except Exception as e:
                 LOG.exception(e)
 
@@ -264,9 +264,6 @@ class PlaybackService(Thread):
         self.status.set_alive()
         if self.audio_enabled:
             LOG.info("Legacy AudioService enabled")
-            if not self.disable_ocp:
-                LOG.warning("OCP has moved to ovos-media, if you already migrated to ovos-media "
-                            'set "disable_ocp": true in mycroft.conf')
             if self.audio.wait_for_load():
                 if len(self.audio.service) == 0:
                     LOG.warning('No audio backends loaded! '

--- a/test/unittests/test_audio_service.py
+++ b/test/unittests/test_audio_service.py
@@ -16,14 +16,13 @@ from ovos_utils.ocp import MediaState
 # helpers
 # ---------------------------------------------------------------------------
 
-def _make_service(disable_ocp=True, validate_source=False, config=None):
+def _make_service(validate_source=False, config=None):
     """Instantiate AudioService with autoload=False so no real plugins load."""
     from ovos_audio.audio import AudioService
     bus = FakeBus()
     cfg = config or {}
     with patch("ovos_audio.audio.Configuration", return_value={"Audio": cfg}):
         svc = AudioService(bus, autoload=False,
-                           disable_ocp=disable_ocp,
                            validate_source=validate_source)
     return svc
 
@@ -50,7 +49,6 @@ class TestLoadServicesOcpExclusion(unittest.TestCase):
                    return_value=found_plugins), \
              patch("ovos_audio.audio.setup_audio_service",
                    return_value=[]) as mock_setup, \
-             patch.object(svc, "find_ocp"), \
              patch.object(svc, "find_default"):
             svc.load_services()
         return mock_setup
@@ -73,60 +71,9 @@ class TestLoadServicesOcpExclusion(unittest.TestCase):
     def test_no_plugins_gives_empty_service_list(self):
         svc = _make_service()
         with patch("ovos_audio.audio.find_audio_service_plugins", return_value={}), \
-             patch.object(svc, "find_ocp"), \
              patch.object(svc, "find_default"):
             svc.load_services()
         self.assertEqual(svc.service, [])
-
-    def test_find_ocp_called_when_not_disabled(self):
-        svc = _make_service(disable_ocp=False)
-        with patch("ovos_audio.audio.find_audio_service_plugins", return_value={}), \
-             patch("ovos_audio.audio.setup_audio_service", return_value=[]), \
-             patch.object(svc, "find_ocp") as mock_ocp, \
-             patch.object(svc, "find_default"):
-            svc.load_services()
-        mock_ocp.assert_called_once()
-
-    def test_find_ocp_called_even_when_disabled(self):
-        """find_ocp is always called; disable_ocp is checked inside it."""
-        svc = _make_service(disable_ocp=True)
-        with patch("ovos_audio.audio.find_audio_service_plugins", return_value={}), \
-             patch("ovos_audio.audio.setup_audio_service", return_value=[]), \
-             patch.object(svc, "find_ocp") as mock_ocp, \
-             patch.object(svc, "find_default"):
-            svc.load_services()
-        mock_ocp.assert_called_once()
-
-
-# ---------------------------------------------------------------------------
-# find_ocp
-# ---------------------------------------------------------------------------
-
-class TestFindOcp(unittest.TestCase):
-
-    def test_disable_ocp_skips_import(self):
-        svc = _make_service(disable_ocp=True)
-        svc.find_ocp()
-        self.assertIsNone(svc.ocp)
-
-    def test_ocp_not_installed_returns_false(self):
-        svc = _make_service(disable_ocp=False)
-        with patch("ovos_audio.audio.Configuration", return_value={"Audio": {}}), \
-             patch.dict("sys.modules", {"ovos_plugin_common_play": None}):
-            result = svc.find_ocp()
-        self.assertFalse(result)
-
-    def test_ocp_installed_instantiates(self):
-        svc = _make_service(disable_ocp=False)
-        mock_backend_cls = MagicMock()
-        mock_ocp_module = MagicMock()
-        mock_ocp_module.OCPAudioBackend = mock_backend_cls
-        with patch("ovos_audio.audio.Configuration", return_value={"Audio": {
-                "backends": {"OCP": {}}}}), \
-             patch.dict("sys.modules", {"ovos_plugin_common_play": mock_ocp_module}):
-            svc.find_ocp()
-        mock_backend_cls.assert_called_once()
-        self.assertIsNotNone(svc.ocp)
 
 
 # ---------------------------------------------------------------------------

--- a/test/unittests/test_audio_service_extended.py
+++ b/test/unittests/test_audio_service_extended.py
@@ -25,13 +25,12 @@ from unittest.mock import MagicMock, patch, call
 from ovos_utils.fakebus import FakeBus
 
 
-def _make_service(disable_ocp=True, validate_source=False, config=None):
+def _make_service(validate_source=False, config=None):
     from ovos_audio.audio import AudioService
     bus = FakeBus()
     cfg = config or {}
     with patch("ovos_audio.audio.Configuration", return_value={"Audio": cfg}):
         svc = AudioService(bus, autoload=False,
-                           disable_ocp=disable_ocp,
                            validate_source=validate_source)
     return svc
 
@@ -615,7 +614,7 @@ class TestLoadServicesRemote(unittest.TestCase):
         remote_backend = MagicMock(spec=RemoteAudioBackend)
 
         with patch("ovos_audio.audio.Configuration", return_value={"Audio": {}}):
-            svc = AudioService(bus, autoload=False, disable_ocp=True, validate_source=False)
+            svc = AudioService(bus, autoload=False, validate_source=False)
 
         local_plugin = MagicMock()
         remote_plugin = MagicMock()
@@ -630,7 +629,6 @@ class TestLoadServicesRemote(unittest.TestCase):
              patch("ovos_audio.audio.setup_audio_service", side_effect=fake_setup), \
              patch("ovos_audio.audio.isinstance",
                    side_effect=lambda obj, cls: cls == RemoteAudioBackend and obj is remote_backend), \
-             patch.object(svc, "find_ocp"), \
              patch.object(svc, "find_default"):
             svc.load_services()
         # set_track_start_callback should be called for each loaded service
@@ -640,7 +638,7 @@ class TestLoadServicesRemote(unittest.TestCase):
         from ovos_audio.audio import AudioService
         bus = FakeBus()
         with patch("ovos_audio.audio.Configuration", return_value={"Audio": {}}):
-            svc = AudioService(bus, autoload=False, disable_ocp=True, validate_source=False)
+            svc = AudioService(bus, autoload=False, validate_source=False)
 
         b1 = MagicMock()
         b2 = MagicMock()
@@ -649,7 +647,6 @@ class TestLoadServicesRemote(unittest.TestCase):
                    return_value={"p1": MagicMock(), "p2": MagicMock()}), \
              patch("ovos_audio.audio.setup_audio_service",
                    side_effect=[[b1], [b2]]), \
-             patch.object(svc, "find_ocp"), \
              patch.object(svc, "find_default"):
             svc.load_services()
 

--- a/test/unittests/test_end2end.py
+++ b/test/unittests/test_end2end.py
@@ -34,8 +34,7 @@ def _simple_plugin_available() -> bool:
 @unittest.skipUnless(_simple_plugin_available(), "ovos_simple audio plugin not installed")
 class TestLegacy(unittest.TestCase):
     def setUp(self):
-        self.core = AudioService(FakeBus(), disable_ocp=True,
-                                 autoload=False,
+        self.core = AudioService(FakeBus(), autoload=False,
                                  validate_source=True)
         self.core.config['default-backend'] = "simple"
         self.core.config['backends'] = {"simple": {

--- a/test/unittests/test_playback_service.py
+++ b/test/unittests/test_playback_service.py
@@ -34,19 +34,9 @@ class TestPlaybackServiceConfigDefaults(unittest.TestCase):
         self.assertIn('"enable_old_audioservice", True', src,
                       "audio_enabled default must be True (TODO: flip to False)")
 
-    def test_disable_ocp_default_is_false(self):
-        src = self._read_defaults_from_source()
-        # The line: disable_ocp = self.config.get("disable_ocp", False)
-        self.assertIn('"disable_ocp", False', src,
-                      "disable_ocp default must be False (TODO: flip to True)")
-
     def test_audio_enabled_config_key_name(self):
         src = self._read_defaults_from_source()
         self.assertIn("enable_old_audioservice", src)
-
-    def test_disable_ocp_config_key_name(self):
-        src = self._read_defaults_from_source()
-        self.assertIn("disable_ocp", src)
 
 
 # ---------------------------------------------------------------------------

--- a/test/unittests/test_remaining_gaps.py
+++ b/test/unittests/test_remaining_gaps.py
@@ -235,36 +235,6 @@ class TestHandleInstantPlayNoUri(unittest.TestCase):
 
 
 # ===========================================================================
-# audio.py:107-109 — OCP player.validate_source exception
-# ===========================================================================
-
-class TestFindOcpValidateSourceException(unittest.TestCase):
-
-    def test_old_ocp_version_warning_logged(self):
-        from ovos_audio.audio import AudioService
-        bus = FakeBus()
-        with patch("ovos_audio.audio.Configuration", return_value={"Audio": {}}):
-            svc = AudioService(bus, autoload=False, disable_ocp=False, validate_source=True)
-
-        mock_backend_cls = MagicMock()
-        mock_ocp = MagicMock()
-        # Setting player.validate_source raises AttributeError (old OCP version)
-        type(mock_ocp.player).validate_source = property(
-            fget=lambda self: None,
-            fset=MagicMock(side_effect=AttributeError("old OCP"))
-        )
-        mock_backend_cls.return_value = mock_ocp
-        mock_ocp_module = MagicMock()
-        mock_ocp_module.OCPAudioBackend = mock_backend_cls
-
-        with patch("ovos_audio.audio.Configuration",
-                   return_value={"Audio": {"backends": {"OCP": {}}}}), \
-             patch.dict("sys.modules", {"ovos_plugin_common_play": mock_ocp_module}):
-            # Should not raise — exception is caught
-            svc.find_ocp()
-
-
-# ===========================================================================
 # audio.py:146 — remote += s (RemoteAudioBackend)
 # ===========================================================================
 
@@ -274,7 +244,7 @@ class TestLoadServicesRemoteBackend(unittest.TestCase):
         from ovos_audio.audio import AudioService, RemoteAudioBackend
         bus = FakeBus()
         with patch("ovos_audio.audio.Configuration", return_value={"Audio": {}}):
-            svc = AudioService(bus, autoload=False, disable_ocp=True, validate_source=False)
+            svc = AudioService(bus, autoload=False, validate_source=False)
 
         # Create a proper RemoteAudioBackend mock instance
         remote_instance = MagicMock(spec=RemoteAudioBackend)
@@ -285,7 +255,6 @@ class TestLoadServicesRemoteBackend(unittest.TestCase):
                    return_value={"my_remote": MagicMock()}), \
              patch("ovos_audio.audio.setup_audio_service",
                    return_value=[remote_instance]), \
-             patch.object(svc, "find_ocp"), \
              patch.object(svc, "find_default"):
             svc.load_services()
         # remote backend should be in service list
@@ -302,14 +271,13 @@ class TestSetTrackStartCallback(unittest.TestCase):
         from ovos_audio.audio import AudioService
         bus = FakeBus()
         with patch("ovos_audio.audio.Configuration", return_value={"Audio": {}}):
-            svc = AudioService(bus, autoload=False, disable_ocp=True, validate_source=False)
+            svc = AudioService(bus, autoload=False, validate_source=False)
 
         b1 = MagicMock()
 
         with patch("ovos_audio.audio.find_audio_service_plugins",
                    return_value={"p1": MagicMock()}), \
              patch("ovos_audio.audio.setup_audio_service", return_value=[b1]), \
-             patch.object(svc, "find_ocp"), \
              patch.object(svc, "find_default"):
             svc.load_services()
         b1.set_track_start_callback.assert_called_with(svc.track_start)

--- a/test/unittests/test_service.py
+++ b/test/unittests/test_service.py
@@ -244,7 +244,7 @@ class TestService(unittest.TestCase):
                          service_names)
         service.shutdown()
 
-        service = AudioService(self.emitter, disable_ocp=True)
+        service = AudioService(self.emitter)
         service_names = [s.name for s in service.service]
         self.assertEqual(service_names, {"ovos_vlc", "ovos_simple"},
                          service_names)


### PR DESCRIPTION
completely remove OCP integration, leave only the legacy audio system around

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

- **New Features**
  - Added a new method `put` to `PlaybackThread` for queuing audio playback

- **Improvements**
  - Enhanced error handling in audio playback methods
  - Simplified audio service initialization process

- **Changes**
  - Removed `disable_ocp` parameter from audio service constructors
  - Streamlined OCP (Open Common Play) functionality

- **Dependency Updates**
  - Updated `ovos-utils` package version requirement
  - Removed `ovos_plugin_common_play[extractors]` dependency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->