### PR TITLE
chore: add warnings

### DIFF
--- a/.github/workflows/build_tests.yml
+++ b/.github/workflows/build_tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.11'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/.github/workflows/license_tests.yml
+++ b/.github/workflows/license_tests.yml
@@ -16,7 +16,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.11'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/.github/workflows/publish_stable.yml
+++ b/.github/workflows/publish_stable.yml
@@ -26,7 +26,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.11'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/.github/workflows/release_workflow.yml
+++ b/.github/workflows/release_workflow.yml
@@ -46,7 +46,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.8
+          python-version: '3.11'
       - name: Install Build Tools
         run: |
           python -m pip install build wheel

--- a/ovos_audio/playback.py
+++ b/ovos_audio/playback.py
@@ -10,7 +10,7 @@ from ovos_config import Configuration
 from ovos_plugin_manager.g2p import OVOSG2PFactory
 from ovos_plugin_manager.templates.g2p import OutOfVocabulary, Grapheme2PhonemePlugin
 from ovos_plugin_manager.templates.tts import TTS
-from ovos_utils.log import LOG, log_deprecation
+from ovos_utils.log import LOG
 from ovos_utils.sound import play_audio
 from time import time
 

--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -1,6 +1,7 @@
 import base64
 import json
 import os
+import warnings
 import os.path
 from hashlib import md5
 from os.path import exists
@@ -183,6 +184,11 @@ class PlaybackService(Thread):
           "active": True,
           "plugin_name": 'Ovos Common Play'}]
         """
+        warnings.warn(
+            "'get_audio_options' is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         opts = []
         return opts
 
@@ -245,6 +251,11 @@ class PlaybackService(Thread):
         "configs" - {backend_name: backend_cfg}}
         "options" - {lang: [list_of_valid_ui_metadata]}
         """
+        warnings.warn(
+            "'handle_opm_audio_query' is deprecated and will be removed in a future release.",
+            DeprecationWarning,
+            stacklevel=2,
+        )
         data = {
             "plugins": [],
             "configs": {},

--- a/ovos_audio/utils.py
+++ b/ovos_audio/utils.py
@@ -14,7 +14,7 @@
 #
 import time
 from functools import wraps
-
+import warnings
 from ovos_bus_client.send_func import send
 from ovos_config import Configuration
 from ovos_utils.log import deprecated, LOG
@@ -60,6 +60,11 @@ def is_speaking():
     Returns:
         bool: True while still speaking
     """
+    warnings.warn(
+        "file signals have been deprecated",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     return check_for_signal("isSpeaking", -1)
 
 
@@ -72,6 +77,11 @@ def wait_while_speaking():
     briefly to ensure that any preceeding request to speak has time to
     begin.
     """
+    warnings.warn(
+        "file signals have been deprecated",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     time.sleep(0.3)  # Wait briefly in for any queued speech to begin
     while is_speaking():
         time.sleep(0.1)
@@ -84,10 +94,13 @@ def stop_speaking():
 
     TODO: Skills should only be able to stop speech they've initiated
     """
+    warnings.warn(
+        "file signals have been deprecated",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     if is_speaking():
-
         send('mycroft.audio.speech.stop')
-
         # Block until stopped
         while check_for_signal("isSpeaking", -1):
             time.sleep(0.25)


### PR DESCRIPTION
make IDEs signal deprecated code instead of relying on runtime logs only

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Deprecation Warnings**
	- Added deprecation warnings for several audio-related functions and methods
	- Notified users about upcoming removal of `get_audio_options` and `handle_opm_audio_query` methods
	- Marked `is_speaking`, `wait_while_speaking`, and `stop_speaking` functions as deprecated

- **Maintenance**
	- Removed unused import statements
	- Prepared codebase for future refactoring by clearly marking deprecated components

<!-- end of auto-generated comment: release notes by coderabbit.ai -->