### PR TITLE
refactor!:drop "native source" and use session_id instead

### DIFF
--- a/.github/workflows/unit_tests.yml
+++ b/.github/workflows/unit_tests.yml
@@ -57,15 +57,8 @@ jobs:
       - name: Run unittests
         run: |
           pytest --cov=ovos_audio --cov-report xml test/unittests
-      - name: Upload coverage
-        env:
-          CODECOV_TOKEN: ${{secrets.CODECOV_TOKEN}}
-        uses: codecov/codecov-action@v3
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          directory: ./coverage/reports/
-          fail_ci_if_error: true
-          files: ./coverage.xml,!./cache
-          flags: unittests
-          name: codecov-unittests
-          verbose: true
+          slug: OpenVoiceOS/ovos-audio

--- a/test/unittests/test_end2end.py
+++ b/test/unittests/test_end2end.py
@@ -20,6 +20,7 @@ from ovos_utils.ocp import MediaState, TrackState, PlayerState
 
 from ovos_audio.service import AudioService
 
+from ovos_bus_client.session import SessionManager, Session
 
 class TestLegacy(unittest.TestCase):
     def setUp(self):
@@ -471,23 +472,16 @@ class TestLegacy(unittest.TestCase):
         self.core.play = play
 
         utt = Message('mycroft.audio.service.play',
-                      {"tracks": ["http://fake.mp3"]},
-                      {"destination": "audio"})  # native source
+                      {"tracks": ["http://fake.mp3"]})
+        utt.context["session"] = Session("default").serialize()
         self.core._play(utt)
 
         self.assertTrue(called)
 
         called = False
         utt = Message('mycroft.audio.service.play',
-                      {"tracks": ["http://fake.mp3"]},
-                      {}) # missing destination
-        self.core._play(utt)
-        self.assertTrue(called)
-
-        called = False
-        utt = Message('mycroft.audio.service.play',
-                      {"tracks": ["http://fake.mp3"]},
-                      {"destination": "hive"})  # external source
+                      {"tracks": ["http://fake.mp3"]})
+        utt.context["session"] = Session("123").serialize()
         self.core._play(utt)
         self.assertFalse(called)
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
	- Transitioned to using a default session for audio control, streamlining playback operations and simplifying configuration.
	- Removed native sources configuration from audio service classes, enhancing initialization simplicity.

- **Tests**
	- Updated unit tests to verify the new session-based behavior, ensuring consistent handling of audio commands during playback and messaging.
	- Adjusted test implementations to reflect changes in message context handling, focusing on session management.

These improvements contribute to a more robust and reliable audio experience for end-users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->