### PR TITLE
Resolve default snd resources from package data

### DIFF
--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -3,6 +3,7 @@ import json
 import os
 import warnings
 import os.path
+from importlib.resources import files
 from hashlib import md5
 from os.path import exists
 from queue import Queue
@@ -29,6 +30,12 @@ from ovos_audio.playback import PlaybackThread
 from ovos_audio.transformers import DialogTransformersService
 from ovos_audio.tts import TTSFactory
 from ovos_audio.utils import report_timing, require_default_session
+
+_DEFAULT_SOUND_PACKAGES = ("ovos_audio", "ovos_dinkum_listener")
+_DEFAULT_SOUND_ALIASES = {
+    "snd/end_listening.wav": "snd/start_listening.wav",
+    "snd/cancel.mp3": "snd/error.mp3",
+}
 
 
 def on_ready():
@@ -476,14 +483,39 @@ class PlaybackService(Thread):
             self.bus.emit(message.forward("mycroft.stop.handled", {"by": "TTS"}))
 
     @staticmethod
+    def _resolve_packaged_sound_uri(uri: str) -> Optional[str]:
+        """Resolve bundled OVOS sounds from installed package resources."""
+        normalized_uri = uri.replace("\\", "/")
+        candidates = [normalized_uri]
+        alias = _DEFAULT_SOUND_ALIASES.get(normalized_uri)
+        if alias and alias not in candidates:
+            candidates.append(alias)
+
+        for candidate in candidates:
+            resource_parts = ("res", *candidate.split("/"))
+            for package in _DEFAULT_SOUND_PACKAGES:
+                try:
+                    resource = files(package).joinpath(*resource_parts)
+                except Exception:
+                    continue
+                if resource.is_file():
+                    return str(resource)
+        return None
+
+    @staticmethod
     def _resolve_sound_uri(uri: str) -> Optional[str]:
         """ helper to resolve sound files full path"""
         if uri is None:
             return None
         if uri.startswith("snd/") or uri.startswith("snd\\"):
-            local_uri = os.path.join(os.path.dirname(__file__), "res", uri)
+            normalized_uri = uri.replace("\\", "/")
+            local_uri = os.path.join(os.path.dirname(__file__), "res",
+                                     normalized_uri)
             if os.path.isfile(local_uri):
                 return local_uri
+            packaged_uri = PlaybackService._resolve_packaged_sound_uri(uri)
+            if packaged_uri:
+                return packaged_uri
         audio_file = resolve_resource_file(uri)
         if audio_file is None or not exists(audio_file):
             raise FileNotFoundError(f"{audio_file} does not exist")

--- a/test/unittests/test_playback_service.py
+++ b/test/unittests/test_playback_service.py
@@ -11,6 +11,7 @@ import os
 import tempfile
 import unittest
 import warnings
+from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 
@@ -132,6 +133,70 @@ class TestResolveSoundUri(unittest.TestCase):
             self.assertEqual(result, path)
         finally:
             os.unlink(path)
+
+    def test_packaged_sound_is_resolved_when_local_copy_is_missing(self):
+        from ovos_audio.service import PlaybackService
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            target = base / "ovos_dinkum_listener" / "res" / "snd" / "_dinkum_only.wav"
+            target.parent.mkdir(parents=True)
+            target.write_bytes(b"FAKE")
+
+            with patch("ovos_audio.service.files",
+                       side_effect=lambda package: base / package), \
+                 patch("ovos_audio.service.resolve_resource_file") as resolve:
+                result = PlaybackService._resolve_sound_uri("snd/_dinkum_only.wav")
+
+        self.assertEqual(result, str(target))
+        resolve.assert_not_called()
+
+    def test_end_listening_alias_reuses_start_listening(self):
+        from ovos_audio.service import PlaybackService
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            target = base / "ovos_dinkum_listener" / "res" / "snd" / "start_listening.wav"
+            target.parent.mkdir(parents=True)
+            target.write_bytes(b"FAKE")
+
+            with patch("ovos_audio.service.files",
+                       side_effect=lambda package: base / package), \
+                 patch("ovos_audio.service.resolve_resource_file") as resolve:
+                result = PlaybackService._resolve_sound_uri("snd/end_listening.wav")
+
+        self.assertEqual(result, str(target))
+        resolve.assert_not_called()
+
+    def test_cancel_alias_reuses_error_sound(self):
+        from ovos_audio.service import PlaybackService
+        with tempfile.TemporaryDirectory() as td:
+            base = Path(td)
+            target = base / "ovos_dinkum_listener" / "res" / "snd" / "error.mp3"
+            target.parent.mkdir(parents=True)
+            target.write_bytes(b"FAKE")
+
+            with patch("ovos_audio.service.files",
+                       side_effect=lambda package: base / package), \
+                 patch("ovos_audio.service.resolve_resource_file") as resolve:
+                result = PlaybackService._resolve_sound_uri("snd/cancel.mp3")
+
+        self.assertEqual(result, str(target))
+        resolve.assert_not_called()
+
+    def test_packaged_sound_miss_falls_through_to_resource_lookup(self):
+        from ovos_audio.service import PlaybackService
+        with tempfile.TemporaryDirectory() as td, \
+                tempfile.NamedTemporaryFile(suffix=".wav", delete=False) as f:
+            path = f.name
+            base = Path(td)
+
+            with patch("ovos_audio.service.files",
+                       side_effect=lambda package: base / package), \
+                 patch("ovos_audio.service.resolve_resource_file",
+                       return_value=path):
+                result = PlaybackService._resolve_sound_uri("snd/nonexistent.wav")
+
+        self.assertEqual(result, path)
+        os.unlink(path)
 
 
 class TestPathFromHexdata(unittest.TestCase):


### PR DESCRIPTION
## Summary
- resolve `snd/*` system sounds from installed OVOS package resources before falling back to generic resource lookup
- add packaged fallbacks for `snd/end_listening.wav` -> `snd/start_listening.wav` and `snd/cancel.mp3` -> `snd/error.mp3`
- cover packaged-resource and alias behavior with unit tests

## Problem
`ovos-audio` can receive valid URIs like `snd/acknowledge.mp3` and still fail with `FileNotFoundError: None does not exist` when the actual sound files are shipped by another installed package such as `ovos_dinkum_listener/res/snd`.

## Validation
```bash
python3.11 -m venv .venv311
.venv311/bin/pip install -e . pytest
.venv311/bin/pytest -q test/unittests/test_playback_service.py test/unittests/test_service_handlers.py
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - The audio service now supports bundled sounds from installed packages, enabling automatic resolution of packaged sound resources when local files aren't found.
  - Added predefined sound aliases to map common audio cues across different package sources.

* **Tests**
  - Added tests for packaged sound resolution behavior, including alias mapping and fallback scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->