### PR TITLE
feat: consume both bus namespaces for speak and stop (PIPELINE-1 §9.6, STOP-1 §5.3)

### DIFF
--- a/docs/audio-service.md
+++ b/docs/audio-service.md
@@ -86,6 +86,7 @@ Track format:
 | `mycroft.audio.service.pause` | Pause current backend |
 | `mycroft.audio.service.resume` | Resume paused backend |
 | `mycroft.audio.service.stop` | Stop playback |
+| `ovos.stop` | Stop playback on the universal stop broadcast (OVOS-STOP-1 §5.3) |
 | `mycroft.audio.service.next` | Skip to next track |
 | `mycroft.audio.service.prev` | Skip to previous track |
 | `mycroft.audio.service.track_info` | Reply with current track metadata |

--- a/docs/playback-service.md
+++ b/docs/playback-service.md
@@ -133,9 +133,11 @@ A decorator defined in `ovos_audio.utils` that guards bus handlers: if `validate
 
 | Event | Handler | Description |
 |---|---|---|
-| `speak` | `handle_speak` | Synthesize and play TTS |
+| `speak` | `handle_speak` | Synthesize and play TTS (legacy topic) |
+| `ovos.utterance.speak` | `handle_speak` | Spec-named NL response topic (OVOS-PIPELINE-1 §9.6) |
 | `speak:b64_audio` | `handle_b64_audio` | Synthesize and return as base64 |
-| `mycroft.stop` | `handle_stop` | Stop current TTS playback |
+| `mycroft.stop` | `handle_stop` | Stop current TTS playback (legacy topic) |
+| `ovos.stop` | `handle_stop` | Universal stop broadcast (OVOS-STOP-1 §5.3) |
 | `mycroft.audio.speech.stop` | `handle_stop` | Stop current TTS playback |
 | `mycroft.audio.speak.status` | `handle_speak_status` | Reply with `{"speaking": bool}` |
 | `mycroft.audio.queue` | `handle_queue_audio` | Queue sound file in TTS thread |
@@ -151,3 +153,18 @@ A decorator defined in `ovos_audio.utils` that guards bus handlers: if `validate
 |---|---|
 | `mycroft.stop.handled` | After TTS queue is cleared on stop |
 | `mycroft.audio.is_speaking` | In reply to `mycroft.audio.speak.status` |
+
+## Spec conformance
+
+The service subscribes to **both** the spec-named topics and their legacy equivalents so
+the two co-exist during the transition:
+
+| Spec | Section | Spec topic | Legacy topic | Handler |
+|---|---|---|---|---|
+| OVOS-PIPELINE-1 | §9.6 | `ovos.utterance.speak` | `speak` | `handle_speak` |
+| OVOS-STOP-1 | §5.3 | `ovos.stop` | `mycroft.stop` | `handle_stop` |
+
+`ovos.utterance.speak` is the spec name for the natural-language response topic. `ovos.stop`
+is the universal stop broadcast: per OVOS-STOP-1 §5.3 a non-skill component with
+user-visible activity MUST cease on it. The legacy `AudioService` (media backends) mirrors
+the same `ovos.stop` subscription — see [audio-service.md](audio-service.md).

--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -168,6 +168,9 @@ class AudioService:
         self.bus.on('mycroft.audio.service.pause', self._pause)
         self.bus.on('mycroft.audio.service.resume', self._resume)
         self.bus.on('mycroft.audio.service.stop', self._stop)
+        # OVOS-STOP-1 §5.3: media playback is user-visible activity — cease on
+        # the universal stop broadcast (alongside the legacy stop topic).
+        self.bus.on('ovos.stop', self._stop)
         self.bus.on('mycroft.audio.service.next', self._next)
         self.bus.on('mycroft.audio.service.prev', self._prev)
         self.bus.on('mycroft.audio.service.track_info', self._track_info)

--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -597,11 +597,17 @@ class PlaybackService(Thread):
         """
         Configuration.set_config_update_handlers(self.bus)
         self.bus.on('mycroft.stop', self.handle_stop)
+        # OVOS-STOP-1 §5.3: a non-skill component with user-visible activity MUST
+        # cease on the universal stop broadcast (alongside the legacy mycroft.stop).
+        self.bus.on('ovos.stop', self.handle_stop)
         self.bus.on('mycroft.audio.speech.stop', self.handle_stop)
         self.bus.on('mycroft.audio.speak.status', self.handle_speak_status)
         self.bus.on('mycroft.audio.queue', self.handle_queue_audio)
         self.bus.on('mycroft.audio.play_sound', self.handle_instant_play)
         self.bus.on('speak', self.handle_speak)
+        # OVOS-PIPELINE-1 §9.6: also consume the spec-named natural-language
+        # response topic (alongside the legacy 'speak' during the transition).
+        self.bus.on('ovos.utterance.speak', self.handle_speak)
         self.bus.on('speak:b64_audio', self.handle_b64_audio)
         self.bus.on('ovos.languages.tts', self.handle_get_languages_tts)
         self.bus.on("opm.tts.query", self.handle_opm_tts_query)

--- a/test/end2end/test_spec_bus_messages_e2e.py
+++ b/test/end2end/test_spec_bus_messages_e2e.py
@@ -1,0 +1,87 @@
+"""Dual bus-message tests for ovos-audio.
+
+ovos-audio is a *subscriber*: it listens on BOTH the legacy and the OVOS spec
+namespaces, so a deployment emitting in either namespace drives audio. Verified:
+- ``speak`` and ``ovos.utterance.speak``           → TTS    (PIPELINE-1 §9.6)
+- ``mycroft.stop`` and ``ovos.stop``               → TTS halts (STOP-1 §5.3)
+- ``mycroft.audio.service.stop`` and ``ovos.stop`` → playback stop (STOP-1 §5.3)
+"""
+import time
+import unittest
+
+from ovos_bus_client.message import Message
+from ovos_utils.fakebus import FakeBus
+
+from ovoscope.audio import AudioServiceHarness, PlaybackServiceHarness
+
+
+class TestSpeakDualTopic(unittest.TestCase):
+    """Both ``speak`` (legacy) and ``ovos.utterance.speak`` (§9.6) drive TTS."""
+
+    def test_legacy_speak_topic_speaks(self):
+        with PlaybackServiceHarness() as h:
+            h.speak("hello legacy")
+            h.assert_spoke("hello legacy")
+
+    def test_spec_utterance_speak_topic_speaks(self):
+        with PlaybackServiceHarness() as h:
+            h.bus.emit(Message("ovos.utterance.speak",
+                               {"utterance": "hello spec", "lang": "en-US"}))
+            h._audio_output_end.wait(timeout=5.0)
+            h.assert_spoke("hello spec")
+
+
+class TestTtsStopDualTopic(unittest.TestCase):
+    """Both ``mycroft.stop`` (legacy) and ``ovos.stop`` (§5.3) halt TTS cleanly."""
+
+    def test_legacy_stop_keeps_service_operational(self):
+        with PlaybackServiceHarness() as h:
+            h.speak("something to say")
+            h.bus.emit(Message("mycroft.stop"))
+            time.sleep(0.1)
+            h.speak("after legacy stop")
+            h.assert_spoke("after legacy stop")
+
+    def test_spec_ovos_stop_keeps_service_operational(self):
+        with PlaybackServiceHarness() as h:
+            h.speak("something to say")
+            h.bus.emit(Message("ovos.stop"))
+            time.sleep(0.1)
+            h.speak("after spec stop")
+            h.assert_spoke("after spec stop")
+
+
+class TestPlaybackStopDualSubscription(unittest.TestCase):
+    """The media playback stop handler is reachable on BOTH the legacy
+    ``mycroft.audio.service.stop`` and the spec ``ovos.stop`` (STOP-1 §5.3)."""
+
+    def _stop_calls_for(self, topic):
+        import ovos_audio.audio as audio_mod
+        seen = []
+        orig = audio_mod.AudioService._stop
+
+        def spy(self, message=None):
+            seen.append(message.msg_type if message else None)
+            return orig(self, message)
+
+        audio_mod.AudioService._stop = spy
+        try:
+            bus = FakeBus()
+            audio_mod.AudioService(bus)
+            time.sleep(0.2)
+            bus.emit(Message(topic))
+            time.sleep(0.2)
+        finally:
+            audio_mod.AudioService._stop = orig
+        return seen
+
+    def test_legacy_service_stop_reaches_handler(self):
+        self.assertIn("mycroft.audio.service.stop",
+                      self._stop_calls_for("mycroft.audio.service.stop"))
+
+    def test_spec_ovos_stop_reaches_handler(self):
+        self.assertIn("ovos.stop", self._stop_calls_for("ovos.stop"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
ovos-audio is a *subscriber*, so it listens on BOTH namespaces (only one is ever emitted by producers): `ovos.utterance.speak` beside `speak` (PIPELINE-1 §9.6), and `ovos.stop` beside `mycroft.stop` / `mycroft.audio.service.stop` for TTS and media playback (STOP-1 §5.3). Part of the org-wide bus-namespace transition. Dual-namespace end2end tests included.

🤖 Generated with [Claude Code](https://claude.com/claude-code)