### PR TITLE
feat!: migrate audio output to OVOS spec bus namespace

### DIFF
--- a/ovos_audio/audio.py
+++ b/ovos_audio/audio.py
@@ -22,6 +22,7 @@ from ovos_plugin_manager.audio import find_audio_service_plugins, \
     setup_audio_service
 from ovos_plugin_manager.ocp import load_stream_extractors
 from ovos_plugin_manager.templates.audio import RemoteAudioBackend
+from ovos_spec_tools import SpecMessage
 from ovos_utils.log import LOG
 from ovos_utils.process_utils import MonotonicEvent
 
@@ -182,8 +183,8 @@ class AudioService:
         self.bus.on('mycroft.audio.service.seek_backward', self._seek_backward)
 
         # audio ducking events
-        self.bus.on('recognizer_loop:audio_output_start', self._lower_volume_on_speak)
-        self.bus.on('recognizer_loop:audio_output_end', self._restore_volume_on_speak)
+        self.bus.on(SpecMessage.AUDIO_OUTPUT_STARTED, self._lower_volume_on_speak)
+        self.bus.on(SpecMessage.AUDIO_OUTPUT_ENDED, self._restore_volume_on_speak)
         self.bus.on('recognizer_loop:record_begin', self._lower_volume_on_record)
         self.bus.on('recognizer_loop:record_end', self._restore_volume_after_record)
         self.bus.on('ovos.utterance.handled', self._restore_volume_on_handled)
@@ -375,7 +376,7 @@ class AudioService:
         if self.current:
             self.bus.on('recognizer_loop:speech.recognition.unknown',
                         restore_volume)
-            speak_msg_detected = self.bus.wait_for_message('speak',
+            speak_msg_detected = self.bus.wait_for_message(SpecMessage.SPEAK,
                                                            timeout=8.0)
             if not speak_msg_detected:
                 restore_volume()
@@ -603,8 +604,8 @@ class AudioService:
         self.bus.remove('mycroft.audio.service.get_track_length', self._get_track_length)
         self.bus.remove('mycroft.audio.service.seek_forward', self._seek_forward)
         self.bus.remove('mycroft.audio.service.seek_backward', self._seek_backward)
-        self.bus.remove('recognizer_loop:audio_output_start', self._lower_volume_on_speak)
+        self.bus.remove(SpecMessage.AUDIO_OUTPUT_STARTED, self._lower_volume_on_speak)
         self.bus.remove('recognizer_loop:record_begin', self._lower_volume_on_record)
-        self.bus.remove('recognizer_loop:audio_output_end', self._restore_volume_on_speak)
+        self.bus.remove(SpecMessage.AUDIO_OUTPUT_ENDED, self._restore_volume_on_speak)
         self.bus.remove('recognizer_loop:record_end', self._restore_volume_after_record)
         self.bus.remove('ovos.utterance.handled', self._restore_volume_on_handled)

--- a/ovos_audio/playback.py
+++ b/ovos_audio/playback.py
@@ -6,6 +6,7 @@ from typing import Optional
 from ovos_audio.transformers import TTSTransformersService
 from ovos_bus_client.message import Message
 from ovos_bus_client.util import get_message_lang
+from ovos_spec_tools import SpecMessage
 from ovos_config import Configuration
 from ovos_plugin_manager.g2p import OVOSG2PFactory
 from ovos_plugin_manager.templates.g2p import OutOfVocabulary, Grapheme2PhonemePlugin
@@ -74,8 +75,8 @@ class PlaybackThread(Thread):
                     self.bus.emit(Message("ovos.common_play.cork"))
                 elif cfg.get("ocp_duck", False):
                     self.bus.emit(Message("ovos.common_play.duck"))
-            message = message or Message("speak")
-            self.bus.emit(message.forward("recognizer_loop:audio_output_start"))
+            message = message or Message(SpecMessage.SPEAK)
+            self.bus.emit(message.forward(SpecMessage.AUDIO_OUTPUT_STARTED))
         else:
             LOG.warning("Speech started before bus was attached.")
 
@@ -94,10 +95,10 @@ class PlaybackThread(Thread):
                 elif cfg.get("ocp_duck", False):
                     self.bus.emit(Message("ovos.common_play.unduck"))
             # Send end of speech signals to the system
-            message = message or Message("speak")
-            self.bus.emit(message.forward("recognizer_loop:audio_output_end"))
+            message = message or Message(SpecMessage.SPEAK)
+            self.bus.emit(message.forward(SpecMessage.AUDIO_OUTPUT_ENDED))
             if listen:
-                self.bus.emit(message.forward('mycroft.mic.listen'))
+                self.bus.emit(message.forward(SpecMessage.MIC_LISTEN))
         else:
             LOG.warning("Speech started before bus was attached.")
 

--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -18,6 +18,7 @@ from ovos_config.config import Configuration
 from ovos_plugin_manager.g2p import get_g2p_lang_configs, get_g2p_supported_langs, get_g2p_module_configs
 from ovos_plugin_manager.tts import TTS
 from ovos_plugin_manager.tts import get_tts_supported_langs, get_tts_lang_configs, get_tts_module_configs
+from ovos_spec_tools import SpecMessage
 from ovos_utils.file_utils import resolve_resource_file
 from ovos_utils.log import LOG, deprecated
 from ovos_utils.metrics import Stopwatch
@@ -328,7 +329,7 @@ class PlaybackService(Thread):
             stopwatch = Stopwatch()
             stopwatch.start()
 
-            utterance = message.data['utterance']
+            utterance = message.data.get('utterance')
 
             # allow dialog transformers to rewrite speech
             skill_id = message.data.get("meta", {}).get("skill") or message.context.get("skill_id")
@@ -604,10 +605,10 @@ class PlaybackService(Thread):
         self.bus.on('mycroft.audio.speak.status', self.handle_speak_status)
         self.bus.on('mycroft.audio.queue', self.handle_queue_audio)
         self.bus.on('mycroft.audio.play_sound', self.handle_instant_play)
-        self.bus.on('speak', self.handle_speak)
-        # OVOS-PIPELINE-1 §9.6: also consume the spec-named natural-language
-        # response topic (alongside the legacy 'speak' during the transition).
-        self.bus.on('ovos.utterance.speak', self.handle_speak)
+        # OVOS-PIPELINE-1 §9.6: consume the spec-named natural-language response
+        # topic. The bus client's modernize flag routes legacy 'speak' emitters
+        # to this listener, so a single spec-namespace subscription suffices.
+        self.bus.on(SpecMessage.SPEAK, self.handle_speak)
         self.bus.on('speak:b64_audio', self.handle_b64_audio)
         self.bus.on('ovos.languages.tts', self.handle_get_languages_tts)
         self.bus.on("opm.tts.query", self.handle_opm_tts_query)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,9 +12,10 @@ requires-python = ">=3.9"
 
 dependencies = [
     "ovos-utils>=0.8.0,<1.0.0",
-    "ovos_bus_client>=1.3.0,<3.0.0",
+    "ovos_bus_client>=2.2.0a1,<3.0.0",
     "ovos-config>=0.0.12,<3.0.0",
     "ovos-plugin-manager>=2.0.0,<3.0.0",
+    "ovos-spec-tools>=0.9.0a1,<1.0.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,13 +8,13 @@ dynamic = ["version"]
 description = "ovos-core audio daemon client"
 readme = "README.md"
 license = "Apache-2.0"
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 
 dependencies = [
     "ovos-utils>=0.8.0,<1.0.0",
     "ovos_bus_client>=2.2.0a1,<3.0.0",
     "ovos-config>=0.0.12,<3.0.0",
-    "ovos-plugin-manager>=2.0.0,<3.0.0",
+    "ovos-plugin-manager>=2.5.0a1,<3.0.0",
     "ovos-spec-tools>=0.9.0a1,<1.0.0",
 ]
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -1,4 +1,4 @@
 ovos-utils>=0.0.38,<1.0.0
-ovos_bus_client>=0.0.8,<3.0.0
+ovos_bus_client>=2.2.0a1,<3.0.0
 ovos-config>=0.0.12,<3.0.0
-ovos-plugin-manager>=0.0.26,<3.0.0
+ovos-plugin-manager>=2.5.0a1,<3.0.0

--- a/test/end2end/test_audio_service_e2e.py
+++ b/test/end2end/test_audio_service_e2e.py
@@ -23,6 +23,7 @@ import time
 import unittest
 
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 from ovos_bus_client.session import Session
 
 from ovoscope.audio import AudioCaptureSession, AudioServiceHarness
@@ -132,10 +133,10 @@ class TestAudioDuckingLowersVolume(unittest.TestCase):
     """Speech start event triggers volume ducking on active backend."""
 
     def test_audio_ducking_lowers_volume(self) -> None:
-        """recognizer_loop:audio_output_start must call lower_volume."""
+        """ovos.audio.output.started must call lower_volume."""
         with AudioServiceHarness() as h:
             h.play(["http://example.com/track.mp3"])
-            h.bus.emit(Message("recognizer_loop:audio_output_start"))
+            h.bus.emit(Message(SpecMessage.AUDIO_OUTPUT_STARTED))
             time.sleep(0.05)
             h.assert_volume_lowered()
             self.assertTrue(h.service.volume_is_speaking)
@@ -145,12 +146,12 @@ class TestAudioDuckingRestoresVolume(unittest.TestCase):
     """Speech end event restores volume after ducking."""
 
     def test_audio_ducking_restores_volume(self) -> None:
-        """recognizer_loop:audio_output_end must call restore_volume."""
+        """ovos.audio.output.ended must call restore_volume."""
         with AudioServiceHarness() as h:
             h.play(["http://example.com/track.mp3"])
-            h.bus.emit(Message("recognizer_loop:audio_output_start"))
+            h.bus.emit(Message(SpecMessage.AUDIO_OUTPUT_STARTED))
             time.sleep(0.05)
-            h.bus.emit(Message("recognizer_loop:audio_output_end"))
+            h.bus.emit(Message(SpecMessage.AUDIO_OUTPUT_ENDED))
             time.sleep(0.05)
             h.assert_volume_restored()
             self.assertFalse(h.service.volume_is_speaking)
@@ -181,10 +182,10 @@ class TestOcpFlagIntegration(unittest.TestCase):
         with AudioServiceHarness(disable_ocp=True) as h:
             h.play(["http://example.com/track.mp3"])
             self.assertFalse(h.service.volume_is_speaking)
-            h.bus.emit(Message("recognizer_loop:audio_output_start"))
+            h.bus.emit(Message(SpecMessage.AUDIO_OUTPUT_STARTED))
             time.sleep(0.05)
             self.assertTrue(h.service.volume_is_speaking)
-            h.bus.emit(Message("recognizer_loop:audio_output_end"))
+            h.bus.emit(Message(SpecMessage.AUDIO_OUTPUT_ENDED))
             time.sleep(0.05)
             self.assertFalse(h.service.volume_is_speaking)
 

--- a/test/end2end/test_audio_service_extended_e2e.py
+++ b/test/end2end/test_audio_service_extended_e2e.py
@@ -31,6 +31,7 @@ import time
 import unittest
 
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 from ovos_bus_client.session import Session
 
 from ovoscope.audio import AudioCaptureSession, AudioServiceHarness
@@ -106,7 +107,7 @@ class TestRestoreVolumeOnHandledWhileSpeaking(unittest.TestCase):
     def test_restore_on_handled_speaking(self) -> None:
         with AudioServiceHarness() as h:
             h.play(["http://example.com/track.mp3"])
-            h.bus.emit(Message("recognizer_loop:audio_output_start"))
+            h.bus.emit(Message(SpecMessage.AUDIO_OUTPUT_STARTED))
             time.sleep(0.05)
             h.assert_volume_lowered()
             self.assertTrue(h.service.volume_is_speaking)

--- a/test/end2end/test_playback_service_e2e.py
+++ b/test/end2end/test_playback_service_e2e.py
@@ -20,6 +20,7 @@ import time
 import unittest
 
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 
 from ovoscope.audio import AudioCaptureSession, PlaybackServiceHarness
 
@@ -33,17 +34,17 @@ class TestSpeakBasic(unittest.TestCase):
             with AudioCaptureSession(bus=h.bus) as cap:
                 h.speak("hello")
             cap.assert_sequence(
-                "recognizer_loop:audio_output_start",
-                "recognizer_loop:audio_output_end",
+                SpecMessage.AUDIO_OUTPUT_STARTED,
+                SpecMessage.AUDIO_OUTPUT_ENDED,
             )
             h.assert_spoke("hello")
 
 
 class TestSpeakExpectResponse(unittest.TestCase):
-    """speak with expect_response=True must trigger mycroft.mic.listen."""
+    """speak with expect_response=True must trigger ovos.mic.listen."""
 
     def test_speak_expect_response(self) -> None:
-        """speak(expect_response=True) must emit mycroft.mic.listen after speech."""
+        """speak(expect_response=True) must emit ovos.mic.listen after speech."""
         with PlaybackServiceHarness() as h:
             h.speak("are you there?", expect_response=True)
             h.assert_audio_output_ended()
@@ -83,8 +84,8 @@ class TestQueueSound(unittest.TestCase):
                     # Wait for playback to complete
                     h._audio_output_end.wait(timeout=5.0)
                 cap.assert_sequence(
-                    "recognizer_loop:audio_output_start",
-                    "recognizer_loop:audio_output_end",
+                    SpecMessage.AUDIO_OUTPUT_STARTED,
+                    SpecMessage.AUDIO_OUTPUT_ENDED,
                 )
         finally:
             os.unlink(wav_path)

--- a/test/end2end/test_playback_service_extended_e2e.py
+++ b/test/end2end/test_playback_service_extended_e2e.py
@@ -34,6 +34,7 @@ import time
 import unittest
 
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 from ovos_bus_client.session import Session
 
 from ovoscope.audio import AudioCaptureSession, PlaybackServiceHarness, SILENT_WAV
@@ -161,7 +162,7 @@ class TestSpeakNonDefaultSessionRejected(unittest.TestCase):
         with PlaybackServiceHarness(validate_source=True) as h:
             custom = Session("non-default-xyz")
             msg = Message(
-                "speak",
+                SpecMessage.SPEAK,
                 {"utterance": "should be rejected"},
                 {"session": custom.serialize()},
             )
@@ -178,7 +179,7 @@ class TestSpeakWithIdentContext(unittest.TestCase):
     def test_speak_with_ident(self) -> None:
         with PlaybackServiceHarness() as h:
             msg = Message(
-                "speak",
+                SpecMessage.SPEAK,
                 {"utterance": "legacy ident test"},
                 {"ident": "abc-123"},
             )
@@ -196,8 +197,8 @@ class TestAudioCaptureSequence(unittest.TestCase):
                 h.speak("capture me")
 
         cap.assert_sequence(
-            "recognizer_loop:audio_output_start",
-            "recognizer_loop:audio_output_end",
+            SpecMessage.AUDIO_OUTPUT_STARTED,
+            SpecMessage.AUDIO_OUTPUT_ENDED,
         )
 
 
@@ -212,9 +213,9 @@ class TestMultipleSpeaksCaptureAllEvents(unittest.TestCase):
                     h.speak(s)
 
         starts = [t for t in cap.message_types
-                  if t == "recognizer_loop:audio_output_start"]
+                  if t == SpecMessage.AUDIO_OUTPUT_STARTED]
         ends = [t for t in cap.message_types
-                if t == "recognizer_loop:audio_output_end"]
+                if t == SpecMessage.AUDIO_OUTPUT_ENDED]
         self.assertGreaterEqual(len(starts), 1,
                                 "At least one audio_output_start must be emitted")
         self.assertGreaterEqual(len(ends), 1,
@@ -237,8 +238,8 @@ class TestQueueSoundWithBinaryData(unittest.TestCase):
                 h._audio_output_end.wait(timeout=5.0)
 
         cap.assert_sequence(
-            "recognizer_loop:audio_output_start",
-            "recognizer_loop:audio_output_end",
+            SpecMessage.AUDIO_OUTPUT_STARTED,
+            SpecMessage.AUDIO_OUTPUT_ENDED,
         )
 
 
@@ -293,8 +294,8 @@ class TestSpeakAfterStop(unittest.TestCase):
                 h._audio_output_end.wait(timeout=5.0)
 
         cap.assert_sequence(
-            "recognizer_loop:audio_output_start",
-            "recognizer_loop:audio_output_end",
+            SpecMessage.AUDIO_OUTPUT_STARTED,
+            SpecMessage.AUDIO_OUTPUT_ENDED,
         )
 
 

--- a/test/end2end/test_spec_bus_messages_e2e.py
+++ b/test/end2end/test_spec_bus_messages_e2e.py
@@ -1,8 +1,9 @@
-"""Dual bus-message tests for ovos-audio.
+"""Spec bus-message tests for ovos-audio.
 
-ovos-audio is a *subscriber*: it listens on BOTH the legacy and the OVOS spec
-namespaces, so a deployment emitting in either namespace drives audio. Verified:
-- ``speak`` and ``ovos.utterance.speak``           → TTS    (PIPELINE-1 §9.6)
+ovos-audio subscribes on the OVOS spec namespace; the bus client's ``modernize``
+flag bridges legacy emitters onto the spec topics, so a single spec subscription
+drives audio regardless of which namespace a deployment emits on. Verified:
+- ``ovos.utterance.speak``                         → TTS    (PIPELINE-1 §9.6)
 - ``mycroft.stop`` and ``ovos.stop``               → TTS halts (STOP-1 §5.3)
 - ``mycroft.audio.service.stop`` and ``ovos.stop`` → playback stop (STOP-1 §5.3)
 """
@@ -10,22 +11,18 @@ import time
 import unittest
 
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 from ovos_utils.fakebus import FakeBus
 
 from ovoscope.audio import AudioServiceHarness, PlaybackServiceHarness
 
 
-class TestSpeakDualTopic(unittest.TestCase):
-    """Both ``speak`` (legacy) and ``ovos.utterance.speak`` (§9.6) drive TTS."""
-
-    def test_legacy_speak_topic_speaks(self):
-        with PlaybackServiceHarness() as h:
-            h.speak("hello legacy")
-            h.assert_spoke("hello legacy")
+class TestSpeakSpecTopic(unittest.TestCase):
+    """The spec ``ovos.utterance.speak`` (§9.6) drives TTS."""
 
     def test_spec_utterance_speak_topic_speaks(self):
         with PlaybackServiceHarness() as h:
-            h.bus.emit(Message("ovos.utterance.speak",
+            h.bus.emit(Message(SpecMessage.SPEAK,
                                {"utterance": "hello spec", "lang": "en-US"}))
             h._audio_output_end.wait(timeout=5.0)
             h.assert_spoke("hello spec")

--- a/test/unittests/test_playback_play.py
+++ b/test/unittests/test_playback_play.py
@@ -11,6 +11,7 @@ import unittest
 from unittest.mock import MagicMock, patch, call, ANY
 
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 
 
 def _make_thread(bus=None, q=None):
@@ -89,7 +90,7 @@ class TestPlayMethod(unittest.TestCase):
         """Return a thread ready for _play() with _now_playing set."""
         bus = bus or MagicMock()
         t = _make_thread(bus=bus)
-        msg = Message("speak", {"utterance": "hello world"}, context={})
+        msg = Message(SpecMessage.SPEAK, {"utterance": "hello world"}, context={})
         t._now_playing = ("/tmp/test.wav", visemes, listen, "test-tts", msg)
         t.on_start = MagicMock()
         t.on_end = MagicMock()

--- a/test/unittests/test_playback_thread.py
+++ b/test/unittests/test_playback_thread.py
@@ -15,6 +15,8 @@ import queue
 import unittest
 from unittest.mock import MagicMock, patch, call
 
+from ovos_spec_tools import SpecMessage
+
 
 def _make_thread(bus=None, q=None):
     """Create a PlaybackThread without starting it."""
@@ -102,7 +104,7 @@ class TestBeginAudio(unittest.TestCase):
         msg = MagicMock()
         msg.forward.return_value = MagicMock()
         t.begin_audio(message=msg)
-        msg.forward.assert_any_call("recognizer_loop:audio_output_start")
+        msg.forward.assert_any_call(SpecMessage.AUDIO_OUTPUT_STARTED)
 
     def test_begin_audio_no_bus_logs_warning(self):
         t = _make_thread(bus=None)
@@ -141,7 +143,7 @@ class TestEndAudio(unittest.TestCase):
         msg = MagicMock()
         msg.forward.return_value = MagicMock()
         t.end_audio(listen=False, message=msg)
-        msg.forward.assert_any_call("recognizer_loop:audio_output_end")
+        msg.forward.assert_any_call(SpecMessage.AUDIO_OUTPUT_ENDED)
 
     def test_end_audio_emits_listen_when_requested(self):
         bus = MagicMock()
@@ -149,7 +151,7 @@ class TestEndAudio(unittest.TestCase):
         msg = MagicMock()
         msg.forward.return_value = MagicMock()
         t.end_audio(listen=True, message=msg)
-        msg.forward.assert_any_call("mycroft.mic.listen")
+        msg.forward.assert_any_call(SpecMessage.MIC_LISTEN)
 
     def test_end_audio_no_listen(self):
         bus = MagicMock()
@@ -158,7 +160,7 @@ class TestEndAudio(unittest.TestCase):
         msg.forward.return_value = MagicMock()
         t.end_audio(listen=False, message=msg)
         forwarded = [c[0][0] for c in msg.forward.call_args_list]
-        self.assertNotIn("mycroft.mic.listen", forwarded)
+        self.assertNotIn(SpecMessage.MIC_LISTEN, forwarded)
 
     def test_end_audio_no_bus_logs_warning(self):
         t = _make_thread(bus=None)

--- a/test/unittests/test_remaining_gaps.py
+++ b/test/unittests/test_remaining_gaps.py
@@ -22,6 +22,7 @@ from threading import Lock
 from unittest.mock import MagicMock, patch, call
 
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 from ovos_utils.fakebus import FakeBus
 
 
@@ -44,7 +45,7 @@ class TestPlayEmptyException(unittest.TestCase):
         """Raise queue.Empty from inside _play's try block — hits line 156."""
         from queue import Empty
         t = _make_thread(bus=MagicMock())
-        msg = Message("speak", {"utterance": "hi"}, context={})
+        msg = Message(SpecMessage.SPEAK, {"utterance": "hi"}, context={})
         t._now_playing = ("/tmp/x.wav", None, False, "tts", msg)
         t.on_start = MagicMock()
         t.on_end = MagicMock()
@@ -69,7 +70,7 @@ class TestRunDequeue(unittest.TestCase):
 
         t._play = fake_play
 
-        msg = Message("speak", {"utterance": "hello"}, context={})
+        msg = Message(SpecMessage.SPEAK, {"utterance": "hello"}, context={})
         q.put(("/tmp/a.wav", None, False, "tts", msg))
         t.run()  # will dequeue, call _play, then terminate
         self.assertEqual(len(called), 1)

--- a/test/unittests/test_service_handlers.py
+++ b/test/unittests/test_service_handlers.py
@@ -31,6 +31,7 @@ from threading import Lock
 from unittest.mock import MagicMock, patch, call
 
 from ovos_bus_client.message import Message
+from ovos_spec_tools import SpecMessage
 from ovos_utils.fakebus import FakeBus
 
 
@@ -185,7 +186,7 @@ class TestHandleSpeak(unittest.TestCase):
 
     def test_ident_in_context_triggers_deprecation_log(self):
         svc = _make_svc()
-        msg = Message("speak", {"utterance": "hello"},
+        msg = Message(SpecMessage.SPEAK, {"utterance": "hello"},
                       context={"ident": "abc123"})
         with patch.object(svc, "execute_tts") as mock_exec, \
              patch("ovos_audio.service.report_timing"):
@@ -198,7 +199,7 @@ class TestHandleSpeak(unittest.TestCase):
         svc.dialog_transform.transform.side_effect = lambda dialog, context=None, sess=None: (
             "TRANSFORMED", context
         )
-        msg = Message("speak",
+        msg = Message(SpecMessage.SPEAK,
                       {"utterance": "original", "meta": {"skill": "my-skill"}},
                       context={})
         called_with = []
@@ -211,7 +212,7 @@ class TestHandleSpeak(unittest.TestCase):
     def test_dialog_transform_not_applied_for_blacklisted_skill(self):
         svc = _make_svc()
         svc.dialog_transform.blacklisted_skills = ["bad-skill"]
-        msg = Message("speak",
+        msg = Message(SpecMessage.SPEAK,
                       {"utterance": "original", "meta": {"skill": "bad-skill"}},
                       context={})
         called_with = []
@@ -223,7 +224,7 @@ class TestHandleSpeak(unittest.TestCase):
 
     def test_handle_speak_no_skill_id(self):
         svc = _make_svc()
-        msg = Message("speak", {"utterance": "no skill"}, context={})
+        msg = Message(SpecMessage.SPEAK, {"utterance": "no skill"}, context={})
         with patch.object(svc, "execute_tts") as mock_exec, \
              patch("ovos_audio.service.report_timing"):
             svc.handle_speak(msg)

--- a/test/unittests/test_speech.py
+++ b/test/unittests/test_speech.py
@@ -20,6 +20,7 @@ from ovos_config import Configuration
 from ovos_utils.messagebus import Message, FakeBus
 from ovos_utils.process_utils import ProcessState
 from ovos_bus_client.session import SessionManager, Session
+from ovos_spec_tools import SpecMessage
 """Tests for speech dispatch service."""
 
 tts_mock = mock.Mock()
@@ -55,7 +56,7 @@ class TestSpeech(unittest.TestCase):
         bus.on.assert_any_call('mycroft.stop', speech.handle_stop)
         bus.on.assert_any_call('mycroft.audio.speech.stop',
                                speech.handle_stop)
-        bus.on.assert_any_call('speak', speech.handle_speak)
+        bus.on.assert_any_call(SpecMessage.SPEAK, speech.handle_speak)
 
         self.assertTrue(speech.status.state > ProcessState.STOPPING)
         speech.shutdown()
@@ -185,7 +186,7 @@ class TestSpeech(unittest.TestCase):
         speech = PlaybackService(bus=bus)
         speech.execute_tts = mock.Mock()
 
-        msg = Message("speak", {"utterance": "hello world"})
+        msg = Message(SpecMessage.SPEAK, {"utterance": "hello world"})
 
         # test message.context.destination
         msg.context["session"] = Session().serialize() # not default


### PR DESCRIPTION
Migrates ovos-audio's bus topics to the OVOS spec namespace via \`SpecMessage\` (PIPELINE-1 §9.6).

## Mapping
| legacy | spec (\`SpecMessage\`) |
|---|---|
| \`speak\` | \`SPEAK\` (\`ovos.utterance.speak\`) |
| \`recognizer_loop:audio_output_start\` | \`AUDIO_OUTPUT_STARTED\` (\`ovos.audio.output.started\`) |
| \`recognizer_loop:audio_output_end\` | \`AUDIO_OUTPUT_ENDED\` (\`ovos.audio.output.ended\`) |
| \`mycroft.mic.listen\` | \`MIC_LISTEN\` (\`ovos.mic.listen\`) |

## Sites
- \`ovos_audio/service.py\`: speak listener now a **single** \`bus.on(SpecMessage.SPEAK, …)\` (drops the legacy dual-listen added in #158); \`handle_speak\` reads payload defensively.
- \`ovos_audio/playback.py\`: \`begin_audio\`/\`end_audio\` emit the spec output + mic.listen topics.
- \`ovos_audio/audio.py\`: ducking \`bus.on\`/\`bus.remove\` + \`wait_for_message\` on spec topics.
- \`pyproject.toml\`: \`ovos-bus-client>=2.2.0a1\`, new direct dep \`ovos-spec-tools>=0.9.0a1\`.
- Unit + e2e tests migrated to the spec topics.

The bus client's \`modernize\` flag bridges legacy \`speak\` emitters onto \`ovos.utterance.speak\`, so a single spec subscription suffices — the previous dual-listen + dedup is no longer needed.

**Out of scope (unchanged):** the stop handshake (\`mycroft.stop\` / \`ovos.stop\` / \`mycroft.audio.speech.stop\` / \`mycroft.stop.handled\`), \`ovos.utterance.handled\`, and all \`mycroft.audio.service.*\` / \`mycroft.audio.speech.*\` topics + method names.

## Stacked / CI
Depends on unpublished **ovos-spec-tools#26** + **ovos-bus-client#230**; the FakeBus e2e suite also needs the companion harness change in **ovoscope** (\`feat/audio-spec-bus-namespace\`). CI stays red until those publish. Verified locally (252 unit + 51 e2e passing) with \`PYTHONPATH\` pointing at the workspace ovos-spec-tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio and speech event handling for more reliable ducking, speak detection, and microphone listen/resume behavior.
  * Made speech requests more tolerant of missing utterance data, reducing unexpected failures in some cases.

* **Chores**
  * Updated supported Python and dependency versions.
  * Aligned tests and internal messaging with the latest audio event standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->