### PR TITLE
fix: floor media-plugin chromecast/spotify to bus-client-2.x prereleases

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,8 @@ test = [
     "ovos-media-plugin-simple>=0.1.0a1, <1.0.0",
 ]
 extras = [
-    "ovos-dialog-normalizer-plugin>=0.0.1, <1.0.0",
-    "ovos-tts-plugin-server>=0.0.2, <1.0.0",
+    "ovos-dialog-normalizer-plugin>=0.0.3a1, <1.0.0",
+    "ovos-tts-plugin-server>=0.0.6a1, <1.0.0",
     "phoonnx>=0.5.4, <1.0.0",
     # media plugins supersede the deprecated ovos-audio-plugin-* backends and
     # expose compatible endpoints: simple + mpv replace the old simple/mpv local

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,8 +41,8 @@ extras = [
     # explicitly (pip install ovos-media-plugin-vlc).
     "ovos-media-plugin-simple>=0.1.0a1, <1.0.0",
     "ovos-media-plugin-mpv>=1.0.0a2, <2.0.0",
-    "ovos-media-plugin-spotify>=0.2.3, <1.0.0",
-    "ovos-media-plugin-chromecast>=0.1.0, <1.0.0",
+    "ovos-media-plugin-spotify>=0.2.8a5, <1.0.0",
+    "ovos-media-plugin-chromecast>=0.1.4a8, <1.0.0",
     "ovos_plugin_common_play[extractors]>=1.3.3a1, <2.0.0",
 ]
 


### PR DESCRIPTION
Stable `ovos-media-plugin-chromecast`/`-spotify` cap `ovos-plugin-manager<2.0`; their cap-free versions are prereleases. Floor at `chromecast>=0.1.4a8`, `spotify>=0.2.8a5` so `ovos-audio[extras]` resolves under bus-client/opm 2.x. Follow-up to #167.

🤖 Generated with [Claude Code](https://claude.com/claude-code)