### PR TITLE
refactor: consume transformer runner services from ovos-plugin-manager

### DIFF
--- a/docs/transformers.md
+++ b/docs/transformers.md
@@ -54,9 +54,22 @@ Only plugins with a config entry are loaded. A plugin with `"active": false` is 
 
 ### Priority Ordering
 
-Plugins are called in descending priority order (highest number first). A plugin with higher priority runs first and its output is the input to the next plugin.
+Plugins are called in **ascending priority order** per OVOS-TRANSFORM §4: a
+plugin with `priority = 1` runs first (default 50), and its output is the
+input to the next plugin — later plugins have the final say. An explicit
+`"order"` list in the config section wins over priorities; loaded plugins
+absent from the list do not run.
 
-Priority `1` is the **last** to run and has the final say on the output.
+The services are the canonical implementations from
+`ovos_plugin_manager.transformer_services` (re-exported by
+`ovos_audio.transformers`) and implement the OVOS-TRANSFORM §8.1
+cancellation contract. Full contract →
+[`ovos-plugin-manager/docs/transformers.md`](../../ovos-plugin-manager/docs/transformers.md).
+
+**Split deployments:** ovos-tts-server can run these same dialog/tts chains
+server-side — the tool for setting a tone/persona globally across every
+device using that server. Enable each plugin in exactly one place or the
+effect is applied twice.
 
 ### Blacklisted Skills
 

--- a/ovos_audio/transformers.py
+++ b/ovos_audio/transformers.py
@@ -9,12 +9,12 @@ from ovos_plugin_manager.tts_transformers import find_tts_transformer_plugins
 
 
 class DialogTransformersService(_DialogTransformersService):
-    """Transforms dialogs before being sent to TTS, in legacy descending
-    priority order: a plugin of priority 1 runs last and has the final say."""
+    """Transforms dialogs before being sent to TTS, in OVOS-TRANSFORM §4
+    ascending priority order: a plugin of priority 1 runs first."""
 
     def __init__(self, bus, config: Optional[dict] = None):
         config = config or Configuration()
-        super().__init__(bus=bus, config=config, sort_ascending=False)
+        super().__init__(bus=bus, config=config)
 
     @classmethod
     def find_plugins(cls):
@@ -22,12 +22,12 @@ class DialogTransformersService(_DialogTransformersService):
 
 
 class TTSTransformersService(_TTSTransformersService):
-    """Transforms wav_files after TTS, in legacy descending priority order:
-    a plugin of priority 1 runs last and has the final say."""
+    """Transforms wav_files after TTS, in OVOS-TRANSFORM §4 ascending
+    priority order: a plugin of priority 1 runs first."""
 
     def __init__(self, bus=None, config: Optional[dict] = None):
         config = config or Configuration()
-        super().__init__(bus=bus, config=config, sort_ascending=False)
+        super().__init__(bus=bus, config=config)
 
     @classmethod
     def find_plugins(cls):

--- a/ovos_audio/transformers.py
+++ b/ovos_audio/transformers.py
@@ -1,166 +1,34 @@
-from ovos_bus_client.session import Session, SessionManager
+from typing import Optional
+
 from ovos_config import Configuration
-from ovos_plugin_manager.dialog_transformers import find_dialog_transformer_plugins, find_tts_transformer_plugins
-from ovos_utils.log import LOG
-from typing import Tuple
+from ovos_plugin_manager.dialog_transformers import find_dialog_transformer_plugins
+from ovos_plugin_manager.transformer_services import (
+    DialogTransformersService as _DialogTransformersService,
+    TTSTransformersService as _TTSTransformersService)
+from ovos_plugin_manager.tts_transformers import find_tts_transformer_plugins
 
 
-class DialogTransformersService:
-    """ transform dialogs before being sent to TTS """
+class DialogTransformersService(_DialogTransformersService):
+    """Transforms dialogs before being sent to TTS, in legacy descending
+    priority order: a plugin of priority 1 runs last and has the final say."""
 
-    def __init__(self, bus, config=None):
-        self.loaded_plugins = {}
-        self.has_loaded = False
-        self.bus = bus
-        # to activate a plugin, just add an entry to mycroft.conf for it
-        self.config = config or Configuration().get("dialog_transformers", {})
-        self.load_plugins()
+    def __init__(self, bus, config: Optional[dict] = None):
+        config = config or Configuration()
+        super().__init__(bus=bus, config=config, sort_ascending=False)
 
-    @property
-    def blacklisted_skills(self):
-        # dialog should NEVER be rewritten if it comes from these skills
-        return self.config.get("blacklisted_skills",
-                               ["skill-ovos-icanhazdadjokes.openvoiceos"] # blacklist jokes by default
-                               )
-
-    def load_plugins(self):
-        for plug_name, plug in find_dialog_transformer_plugins().items():
-            if plug_name in self.config:
-                # if disabled skip it
-                if not self.config[plug_name].get("active", True):
-                    continue
-                try:
-                    self.loaded_plugins[plug_name] = plug(config=self.config[plug_name])
-                    self.loaded_plugins[plug_name].bind(self.bus)
-                    LOG.info(f"loaded audio transformer plugin: {plug_name}")
-                except Exception as e:
-                    LOG.exception(f"Failed to load dialog transformer plugin: "
-                                  f"{plug_name}")
-        self.has_loaded = True
-
-    @property
-    def plugins(self) -> list:
-        """
-        Return loaded transformers in priority order, such that modules with a
-        higher `priority` rank are called first and changes from lower ranked
-        transformers are applied last.
-
-        A plugin of `priority` 1 will override any existing context keys and
-        will be the last to modify `audio_data`
-        """
-        return sorted(self.loaded_plugins.values(),
-                      key=lambda k: k.priority, reverse=True)
-
-    def shutdown(self):
-        """
-        Shutdown all loaded plugins
-        """
-        for module in self.plugins:
-            try:
-                module.shutdown()
-            except Exception as e:
-                LOG.warning(e)
-
-    def transform(self, dialog: str, context: dict = None, sess: Session = None) -> Tuple[str, dict]:
-        """
-        Get transformed audio and context for the preceding audio
-        @param dialog: str to be spoken
-        @return: transformed dialog to be sent to TTS
-        """
-
-        # TODO property not yet introduced in Session
-        sess = sess or SessionManager.get()
-        # if isinstance(sess, dict):
-        #    sess = Session.deserialize(sess)
-        # active_transformers = sess.dialog_transformers or self.plugins
-
-        active_transformers = self.plugins
-
-        for module in active_transformers:
-            try:
-                LOG.debug(f"checking dialog transformer: {module}")
-                dialog, context = module.transform(dialog, context=context)
-                LOG.debug(f"{module.name}: {dialog}")
-            except Exception as e:
-                LOG.exception(e)
-        return dialog, context
+    @classmethod
+    def find_plugins(cls):
+        return find_dialog_transformer_plugins().items()
 
 
-class TTSTransformersService:
-    """ transform wav_files after TTS """
+class TTSTransformersService(_TTSTransformersService):
+    """Transforms wav_files after TTS, in legacy descending priority order:
+    a plugin of priority 1 runs last and has the final say."""
 
-    def __init__(self, bus=None, config=None):
-        self.loaded_plugins = {}
-        self.has_loaded = False
-        self.bus = bus
-        # to activate a plugin, just add an entry to mycroft.conf for it
-        self.config = config or Configuration().get("tts_transformers", {})
-        self.load_plugins()
+    def __init__(self, bus=None, config: Optional[dict] = None):
+        config = config or Configuration()
+        super().__init__(bus=bus, config=config, sort_ascending=False)
 
-    def load_plugins(self):
-        for plug_name, plug in find_tts_transformer_plugins().items():
-            if plug_name in self.config:
-                # if disabled skip it
-                if not self.config[plug_name].get("active", True):
-                    continue
-                try:
-                    self.loaded_plugins[plug_name] = plug(config=self.config[plug_name])
-                    if self.bus:
-                        self.loaded_plugins[plug_name].bind(self.bus)
-                    LOG.info(f"loaded audio transformer plugin: {plug_name}")
-                except Exception as e:
-                    LOG.exception(f"Failed to load tts transformer plugin: "
-                                  f"{plug_name}")
-        self.has_loaded = True
-
-    def set_bus(self, bus):
-        self.bus = bus
-        for p in self.loaded_plugins.values():
-            p.bind(self.bus)
-
-    @property
-    def plugins(self) -> list:
-        """
-        Return loaded transformers in priority order, such that modules with a
-        higher `priority` rank are called first and changes from lower ranked
-        transformers are applied last.
-
-        A plugin of `priority` 1 will override any existing context keys and
-        will be the last to modify `audio_data`
-        """
-        return sorted(self.loaded_plugins.values(),
-                      key=lambda k: k.priority, reverse=True)
-
-    def shutdown(self):
-        """
-        Shutdown all loaded plugins
-        """
-        for module in self.plugins:
-            try:
-                module.shutdown()
-            except Exception as e:
-                LOG.warning(e)
-
-    def transform(self, wav_file: str, context: dict = None, sess: Session = None) -> Tuple[str, dict]:
-        """
-        Get transformed audio and context for the preceding audio
-        @param wav_file: str path for the TTS wav file
-        @return: path to transformed wav file
-        """
-
-        # TODO property not yet introduced in Session
-        sess = sess or SessionManager.get()
-        # if isinstance(sess, dict):
-        #    sess = Session.deserialize(sess)
-        # active_transformers = sess.tts_transformers or self.plugins
-
-        active_transformers = self.plugins
-
-        for module in active_transformers:
-            try:
-                LOG.debug(f"checking tts transformer: {module}")
-                wav_file, context = module.transform(wav_file, context=context or {})
-                LOG.debug(f"{module.name}: {wav_file}")
-            except Exception as e:
-                LOG.exception(e)
-        return wav_file, context
+    @classmethod
+    def find_plugins(cls):
+        return find_tts_transformer_plugins().items()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ dependencies = [
     "ovos-utils>=0.8.0,<1.0.0",
     "ovos_bus_client>=2.5.1a1,<3.0.0",
     "ovos-config>=0.0.12,<3.0.0",
-    "ovos-plugin-manager>=2.5.0a1,<3.0.0",
+    "ovos-plugin-manager>=2.10.0a1,<3.0.0",
     "ovos-spec-tools>=0.17.3a1",
 ]
 

--- a/test/unittests/test_transformers.py
+++ b/test/unittests/test_transformers.py
@@ -51,7 +51,7 @@ class TestDialogTransformersServiceInit(unittest.TestCase):
         svc = self._make()
         dialog, ctx = svc.transform("test")
         self.assertEqual(dialog, "test")
-        self.assertIsNone(ctx)
+        self.assertEqual(ctx, {})
 
     def test_shutdown_no_plugins(self):
         svc = self._make()
@@ -177,7 +177,7 @@ class TestTTSTransformersService(unittest.TestCase):
         svc = self._make()
         result, ctx = svc.transform("/tmp/test.wav")
         self.assertEqual(result, "/tmp/test.wav")
-        self.assertIsNone(ctx)
+        self.assertEqual(ctx, {})
 
     def test_set_bus_propagates_to_plugins(self):
         svc = self._make()


### PR DESCRIPTION
## What

Replaces the local `DialogTransformersService` and `TTSTransformersService` implementations in `ovos_audio/transformers.py` with thin subclasses of the canonical runners added to ovos-plugin-manager in OpenVoiceOS/ovos-plugin-manager#410.

Class names, import paths, constructor signatures, the `blacklisted_skills` default and `set_bus()` are unchanged; plugin loading stays config-gated and opt-in. `transform()` with no context now returns an empty dict instead of passing `None` through.

## Breaking change: OVOS-TRANSFORM §4 chain ordering

Dialog and TTS transformer chains now run in **ascending priority order** per OVOS-TRANSFORM §4 — a plugin with `priority = 1` runs first. The previous descending traversal was non-spec. An explicit `"order"` list in the config section (new, per §4) wins over priorities. The runners also implement the §8.1 cancellation contract (valid `canceled`/`cancel_reason` pair stops the chain, `cancel_by` stamped by the runner).

## Depends on

- OpenVoiceOS/ovos-plugin-manager#410 — must merge and release first; this PR pins `ovos-plugin-manager>=2.10.0a1`. CI stays red until that alpha is on PyPI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Transformer services now support centralized plugin handling and configurable execution order.
  * Explicit transformer ordering can override priority-based ordering.
  * Added guidance for split deployments to prevent duplicate transformations.

* **Bug Fixes**
  * Transformer operations now return an empty context when none is provided.

* **Documentation**
  * Clarified ascending priority behavior and cancellation handling for transformer plugins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->