### PR TITLE
feat: run ServiceInstaller (install plugins into the audio env over the bus)

### DIFF
--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -23,6 +23,7 @@ from ovos_utils.file_utils import resolve_resource_file
 from ovos_utils.log import LOG, deprecated
 from ovos_utils.metrics import Stopwatch
 from ovos_utils.process_utils import ProcessStatus, StatusCallbackMap
+from ovos_utils.skill_installer import ServiceInstaller
 from ovos_utils.sound import play_audio
 
 from ovos_audio.audio import AudioService
@@ -87,6 +88,10 @@ class PlaybackService(Thread):
         self.bus = bus
         self.status.bind(self.bus)
         self.init_messagebus()
+        # Install/uninstall plugins into THIS service's environment when asked
+        # over the bus (ovos.pip.install / ovos.pip.install.ovos-audio). Gated
+        # by the 'skills.installer.allow_pip' config, off by default.
+        self.installer = ServiceInstaller(self.bus, service_name="ovos_audio")
         self.dialog_transform = DialogTransformersService(self.bus)
         if TTS.queue is None:
             TTS.queue = Queue()
@@ -620,6 +625,8 @@ class PlaybackService(Thread):
         Stop any playing audio and make sure threads are joined correctly.
         """
         self.status.set_stopping()
+        if getattr(self, "installer", None):
+            self.installer.shutdown()
         if self.playback_thread:
             self.playback_thread.shutdown()
             self.playback_thread.join()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,7 +11,7 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 
 dependencies = [
-    "ovos-utils>=0.8.0,<1.0.0",
+    "ovos-utils>=0.8.5,<1.0.0",
     "ovos_bus_client>=2.5.1a1,<3.0.0",
     "ovos-config>=0.0.12,<3.0.0",
     "ovos-plugin-manager>=2.10.0a1,<3.0.0",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 4.8 (claude-opus-4-8) via Claude Code — NOT human-reviewed. Verify before acting.

## What

Run `ovos_utils.skill_installer.ServiceInstaller` inside `PlaybackService` so
**ovos-audio installs plugins into its own environment over the message bus**.

It answers:

- the broadcast `ovos.pip.install` / `ovos.pip.uninstall`, and
- the **targeted** `ovos.pip.install.ovos_audio` / `ovos.pip.uninstall.ovos_audio`

replying on the base `ovos.pip.install.complete` / `.failed` topics.

## Why

In a split or containerised deployment each service owns a separate venv. A TTS
/ media / audio plugin must be installed into the process that actually loads it
— the audio service — not wherever the requester happens to run. Targeted
installs make that land in the right container. This is the audio-service half
of a fleet of companion PRs (listener, gui, PHAL, core) that give every service
its own installer; the [ovos-webui](https://github.com/OpenVoiceOS/ovos-webui)
plugin browser routes each plugin family to the owning service by this topic.

## service_name convention

`service_name="ovos_audio"` — the module/process name with underscores,
following `ServiceInstaller`'s own documented convention (its docstring lists
`ovos_audio`, `ovos_gui`, `ovos_core`, `ovos_messagebus`). The web-ui routing
map and every companion PR use this same underscore module-name form so the
targeted topics line up exactly.

## Safety

Gated by the existing `skills.installer.allow_pip` config — **off by default**,
so this changes nothing unless an operator opts in. The installer is cleanly
unregistered in `shutdown()`.

## Changes

- `ovos_audio/service.py`: instantiate `ServiceInstaller(self.bus,
  service_name="ovos_audio")` after the bus connects; shut it down on stop.
- `pyproject.toml`: bump `ovos-utils` floor to `>=0.8.5` (where
  `ServiceInstaller` landed).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for installing and uninstalling audio service plugins through system bus requests.

* **Bug Fixes**
  * Improved service shutdown handling to ensure plugin installation services close cleanly.

* **Chores**
  * Updated the minimum supported utility package version for improved compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->