### PR TITLE
fix: reload the TTS engine when the plugin changes

### DIFF
--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -53,6 +53,19 @@ def on_stopping():
     LOG.info('TTS service is shutting down...')
 
 
+def tts_config_hash(tts_config: dict, module: str) -> int:
+    """Hash what decides whether a TTS engine has to be rebuilt.
+
+    The plugin name takes part in the hash, not only its settings block. Two
+    plugins that carry no settings of their own both hash to an empty block, so
+    without the name a swap between them looks like no change and the old engine
+    keeps speaking until the service restarts.
+    """
+    return hash(json.dumps({"module": module,
+                            "config": tts_config.get(module, {})},
+                           sort_keys=True))
+
+
 class PlaybackService(Thread):
     def __init__(self, ready_hook=on_ready, error_hook=on_error,
                  stopping_hook=on_stopping, alive_hook=on_alive,
@@ -384,10 +397,8 @@ class PlaybackService(Thread):
         config = Configuration().get("tts", {})
         tts_m = config.get("module", "")
         ftts_m = config.get("fallback_module", "")
-        _tts_hash = hash(json.dumps(config.get(tts_m, {}),
-                                    sort_keys=True))
-        _ftts_hash = hash(json.dumps(config.get(ftts_m, {}),
-                                     sort_keys=True))
+        _tts_hash = tts_config_hash(config, tts_m)
+        _ftts_hash = tts_config_hash(config, ftts_m)
 
         # update TTS object if configuration has changed
         if not self._tts_hash or self._tts_hash != _tts_hash:
@@ -418,6 +429,11 @@ class PlaybackService(Thread):
             with self.lock:
                 if self.fallback_tts:
                     self.fallback_tts.shutdown()
+                    # _get_tts_fallback only builds an engine when there is
+                    # none, and shutdown does not clear the attribute, so the
+                    # old one has to go or the reload hands back the engine it
+                    # just shut down.
+                    self.fallback_tts = None
                 # Create new tts instance
                 LOG.info("(re)loading fallback TTS engine")
                 self._get_tts_fallback()

--- a/test/unittests/test_remaining_gaps.py
+++ b/test/unittests/test_remaining_gaps.py
@@ -348,3 +348,103 @@ class TestReportTiming(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+# ===========================================================================
+# service.py — _maybe_reload_tts: the module name must take part in the hash
+# ===========================================================================
+
+class TestReloadOnModuleChange(unittest.TestCase):
+    """Swapping tts.module must reload the engine.
+
+    The reload hash covered only the selected module's own settings block. Two
+    plugins with no settings of their own therefore hashed identically, so the
+    swap looked like no change and the old engine kept speaking until the
+    service restarted.
+    """
+
+    @staticmethod
+    def _cfg(module):
+        return {"tts": {"module": module, "fallback_module": "", "preload_fallback": False}}
+
+    def _reload_with(self, svc, module, new_tts):
+        with patch("ovos_audio.service.Configuration", return_value=self._cfg(module)), \
+             patch("ovos_audio.service.TTSFactory.create", return_value=new_tts), \
+             patch.object(svc, "_get_tts_fallback"):
+            svc._maybe_reload_tts()
+
+    def test_changing_the_module_reloads_even_without_a_settings_block(self):
+        old = MagicMock()
+        svc = _make_svc(tts=old, disable_fallback=True)
+        self._reload_with(svc, "ovos-tts-plugin-mimic3", MagicMock())
+        first_hash = svc._tts_hash
+
+        new = MagicMock()
+        self._reload_with(svc, "ovos-tts-plugin-piper", new)
+
+        self.assertNotEqual(first_hash, svc._tts_hash,
+                            "the module name is not part of the reload hash")
+        self.assertIs(svc.tts, new, "the engine was not swapped")
+
+    def test_saving_the_same_module_again_does_not_reload(self):
+        svc = _make_svc(tts=MagicMock(), disable_fallback=True)
+        self._reload_with(svc, "ovos-tts-plugin-piper", MagicMock())
+        settled = svc.tts
+
+        self._reload_with(svc, "ovos-tts-plugin-piper", MagicMock())
+        self.assertIs(svc.tts, settled, "an unchanged configuration reloaded anyway")
+
+    def test_changing_the_fallback_module_reloads_the_fallback(self):
+        svc = _make_svc(tts=MagicMock(), fallback_tts=MagicMock())
+        cfg = {"tts": {"module": "main", "fallback_module": "fb-one",
+                       "preload_fallback": True}}
+        with patch("ovos_audio.service.Configuration", return_value=cfg), \
+             patch("ovos_audio.service.TTSFactory.create", return_value=MagicMock()), \
+             patch.object(svc, "_get_tts_fallback"):
+            svc._maybe_reload_tts()
+        first = svc._fallback_tts_hash
+
+        cfg["tts"]["fallback_module"] = "fb-two"
+        with patch("ovos_audio.service.Configuration", return_value=cfg), \
+             patch("ovos_audio.service.TTSFactory.create", return_value=MagicMock()), \
+             patch.object(svc, "_get_tts_fallback"):
+            svc._maybe_reload_tts()
+
+        self.assertNotEqual(first, svc._fallback_tts_hash,
+                            "the fallback module name is not part of its hash")
+
+
+class TestFallbackReloadReplacesTheEngine(unittest.TestCase):
+    """Reloading the fallback must produce the NEW plugin, not the old one.
+
+    `_get_tts_fallback` is lazy: it builds an engine only `if not
+    self.fallback_tts`. Shutting the old one down does not clear the attribute,
+    so the reload branch shut the engine down and then handed the same dead
+    object straight back. The tests around this mocked `_get_tts_fallback`,
+    which is exactly why it went unseen.
+    """
+
+    def test_changing_the_fallback_module_builds_the_new_one(self):
+        old_fallback = MagicMock()
+        svc = _make_svc(tts=MagicMock(), fallback_tts=old_fallback)
+        svc._tts_hash = None
+        svc._fallback_tts_hash = "stale"
+
+        cfg = {"tts": {"module": "main", "fallback_module": "fb-two",
+                       "preload_fallback": True}}
+        created = []
+
+        def _create(config):
+            engine = MagicMock()
+            created.append(config.get("tts", {}).get("module"))
+            return engine
+
+        # _get_tts_fallback is deliberately NOT mocked: it is what was broken.
+        with patch("ovos_audio.service.Configuration", return_value=cfg), \
+             patch("ovos_audio.service.TTSFactory.create", side_effect=_create):
+            svc._maybe_reload_tts()
+
+        old_fallback.shutdown.assert_called_once()
+        self.assertIsNot(svc.fallback_tts, old_fallback,
+                         "the shut-down fallback engine is still in use")
+        self.assertIn("fb-two", created,
+                      f"the replacement fallback was never built: {created}")

--- a/test/unittests/test_service_handlers.py
+++ b/test/unittests/test_service_handlers.py
@@ -270,10 +270,9 @@ class TestMaybeReloadTts(unittest.TestCase):
     def test_disable_fallback_skips_fallback_reload(self):
         svc = _make_svc()
         svc.disable_fallback = True
-        svc._tts_hash = "same"
-        cfg = {"module": "dummy", "dummy": {}}
-        import json
-        svc._tts_hash = hash(json.dumps({}, sort_keys=True))
+        from ovos_audio.service import tts_config_hash
+        # the hash the service will compute, so nothing needs reloading
+        svc._tts_hash = tts_config_hash({"module": "dummy"}, "dummy")
         with patch("ovos_audio.service.Configuration",
                    return_value={"tts": {"module": "dummy"}}), \
              patch("ovos_audio.service.TTSFactory") as mock_factory:
@@ -284,8 +283,9 @@ class TestMaybeReloadTts(unittest.TestCase):
 
     def test_preload_fallback_false_skips(self):
         svc = _make_svc()
-        svc._tts_hash = hash(json.dumps({}, sort_keys=True))
+        from ovos_audio.service import tts_config_hash
         cfg = {"module": "main", "fallback_module": "fallback", "preload_fallback": False}
+        svc._tts_hash = tts_config_hash(cfg, "main")
         with patch("ovos_audio.service.Configuration", return_value={"tts": cfg}), \
              patch("ovos_audio.service.TTSFactory") as mock_factory:
             svc._maybe_reload_tts()
@@ -293,8 +293,9 @@ class TestMaybeReloadTts(unittest.TestCase):
 
     def test_same_module_skips_fallback(self):
         svc = _make_svc()
-        svc._tts_hash = hash(json.dumps({}, sort_keys=True))
+        from ovos_audio.service import tts_config_hash
         cfg = {"module": "same", "fallback_module": "same"}
+        svc._tts_hash = tts_config_hash(cfg, "same")
         with patch("ovos_audio.service.Configuration", return_value={"tts": cfg}), \
              patch("ovos_audio.service.TTSFactory") as mock_factory:
             svc._maybe_reload_tts()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.
> Verified against source and by executed tests in this repo. Not verified: behaviour on a live device.

Fixes #186.

`_maybe_reload_tts` decided whether to rebuild the engine by hashing only the selected plugin's own settings block:

```python
_tts_hash = hash(json.dumps(config.get(tts_m, {}), sort_keys=True))
```

`tts_m` is used as a lookup key and never enters the hash. Two plugins that carry no settings of their own both hash to `{}`, so swapping between them looked like no change and the old engine kept speaking until the service restarted. Adding any settings block to one of them made the hashes differ and the swap worked, which is why this did not always show up.

The listener already does this correctly — `ovos_dinkum_listener` puts `"module": stt_module` into the dict it hashes. This uses the same shape, for the fallback engine as well.

## The change

```python
def tts_config_hash(tts_config: dict, module: str) -> int:
    return hash(json.dumps({"module": module,
                            "config": tts_config.get(module, {})},
                           sort_keys=True))
```

Both hashes are built through it. Pulling it out of the method is not only tidiness: three existing tests in `test_service_handlers.py` were setting `svc._tts_hash = hash(json.dumps({}, sort_keys=True))` to mean "nothing needs reloading", which reproduced the hash's internal shape and broke the moment that shape changed. They now ask for the value the service will actually compute, so they will not go stale again.

## A second bug, exposed by fixing the first

Making the fallback branch actually fire showed that it could not do its job.

`_get_tts_fallback` is lazy — it builds an engine only `if not self.fallback_tts` — and `shutdown()` does not clear the attribute:

```python
if self.fallback_tts:
    self.fallback_tts.shutdown()
LOG.info("(re)loading fallback TTS engine")
self._get_tts_fallback()      # sees the old object, returns it unchanged
```

So a fallback swap shut the old engine down and then handed the same dead object straight back. Before this PR the branch almost never ran, so it did not show; with the hash fixed it runs whenever `fallback_module` changes. `self.fallback_tts = None` after the shutdown.

Both existing tests around this mocked `_get_tts_fallback`, which is precisely why nobody saw it. The new test leaves it unmocked and asserts the replacement module is the one built. It fails without the one-line fix.

Thanks to the reviewer who spotted this — I would not have found it, because my own test mocked past it.

## Tests

`TestReloadOnModuleChange` in `test/unittests/test_remaining_gaps.py`:

- changing the module reloads even when neither plugin has a settings block
- saving the same module again does **not** reload (the no-op case still holds)
- changing the fallback module reloads the fallback

The first and third fail on `dev` and pass here. The second passes both ways, which is the point of including it.

Full unit suite: 271 passed, 17 skipped.

## Why it was noticed

ovos-control-panel writes `tts.module` and tells the user the change applies without a restart. That is true for STT, the wake word and VAD, and was false for TTS. The panel is wording around it for now; with this merged it can stop.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved text-to-speech engine switching so changes between different TTS modules reliably reload the correct engine, even when their settings are otherwise identical.
  - Preserved expected behavior when configurations remain unchanged or fallback engines are disabled.

- **Tests**
  - Added coverage for main and fallback TTS module changes, unchanged configurations, and fallback loading scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->