### PR TITLE
fix: include requested uri in _resolve_sound_uri error message

### DIFF
--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -542,7 +542,7 @@ class PlaybackService(Thread):
                 return local_uri
         audio_file = resolve_resource_file(uri)
         if audio_file is None or not exists(audio_file):
-            raise FileNotFoundError(f"{audio_file} does not exist")
+            raise FileNotFoundError(f"could not resolve sound uri: {uri}")
         return audio_file
 
     @staticmethod

--- a/test/unittests/test_playback_service.py
+++ b/test/unittests/test_playback_service.py
@@ -118,6 +118,13 @@ class TestResolveSoundUri(unittest.TestCase):
         with self.assertRaises((FileNotFoundError, Exception)):
             PlaybackService._resolve_sound_uri("/does/not/exist.wav")
 
+    def test_nonexistent_file_error_names_requested_uri(self):
+        from ovos_audio.service import PlaybackService
+        uri = "no/such/sound-file-xyz.wav"
+        with self.assertRaises(FileNotFoundError) as excinfo:
+            PlaybackService._resolve_sound_uri(uri)
+        self.assertIn(uri, str(excinfo.exception))
+
     def test_none_returns_none(self):
         from ovos_audio.service import PlaybackService
         result = PlaybackService._resolve_sound_uri(None)


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

When AudioService._resolve_sound_uri fails to resolve a sound file, it raises a FileNotFoundError built from the already-failed resolution result rather than the uri that was actually requested. Since that result is always None on the failing branch, the error always reads "None does not exist" no matter which sound file was missing, which is exactly what a deployed box logged when it hit this path. There is no way for whoever is reading the log to tell which sound could not be found.

The fix raises with the requested uri instead of the resolved (and always None) value, so the message names the actual file that failed to resolve.

Added a regression test alongside the existing _resolve_sound_uri tests in test/unittests/test_playback_service.py that calls the method with a nonexistent uri and asserts the uri appears in the exception message. Confirmed the test fails against the unfixed source with AssertionError: 'no/such/sound-file-xyz.wav' not found in 'None does not exist', and passes after the fix. The full unit test suite (273 passed, 17 skipped) is unaffected.