### PR TITLE
fix: contain crash-shaped exceptions in playback bus handlers

### DIFF
--- a/ovos_audio/service.py
+++ b/ovos_audio/service.py
@@ -577,8 +577,14 @@ class PlaybackService(Thread):
                 audio_file = self._path_from_hexdata(hex_audio, audio_ext)
 
             if not audio_file:
-                raise ValueError(f"message.data needs to provide 'uri' or 'binary_data': {message.data}")
-            audio_file = self._resolve_sound_uri(audio_file)
+                LOG.warning(f"{SpecMessage.AUDIO_QUEUE} message.data needs to provide "
+                            f"'uri' or 'binary_data': {message.data}")
+                return
+            try:
+                audio_file = self._resolve_sound_uri(audio_file)
+            except FileNotFoundError as e:
+                LOG.warning(f"{SpecMessage.AUDIO_QUEUE} could not resolve sound uri: {e}")
+                return
 
             listen = message.data.get("listen", False)
 
@@ -595,9 +601,15 @@ class PlaybackService(Thread):
         if hex_audio:
             audio_file = self._path_from_hexdata(hex_audio, audio_ext)
         if not audio_file:
-            raise ValueError(f"message.data needs to provide 'uri' or 'binary_data': {message.data}")
+            LOG.warning(f"{SpecMessage.AUDIO_PLAY_SOUND} message.data needs to provide "
+                        f"'uri' or 'binary_data': {message.data}")
+            return
 
-        audio_file = self._resolve_sound_uri(audio_file)
+        try:
+            audio_file = self._resolve_sound_uri(audio_file)
+        except FileNotFoundError as e:
+            LOG.warning(f"{SpecMessage.AUDIO_PLAY_SOUND} could not resolve sound uri: {e}")
+            return
 
         # volume handling and audio service ducking
         ensure_volume = message.data.get("force_unmute", False)

--- a/test/unittests/test_playback_service.py
+++ b/test/unittests/test_playback_service.py
@@ -188,5 +188,52 @@ class TestPathFromHexdata(unittest.TestCase):
         self.assertEqual(path1, path2)
 
 
+class TestPlaybackHandlersDontCrashOnBadSound(unittest.TestCase):
+    """A missing sound file or malformed message must be logged and
+    swallowed by the bus handlers, never raised into pyee's emit."""
+
+    def _make_minimal_service(self):
+        from ovos_audio.service import PlaybackService
+        from threading import Lock
+        svc = PlaybackService.__new__(PlaybackService)
+        svc.bus = MagicMock()
+        svc.playback_lock = Lock()
+        svc.tts = None
+        svc.validate_source = False
+        return svc
+
+    def test_handle_instant_play_unresolvable_uri_logs_and_returns(self):
+        svc = self._make_minimal_service()
+        msg = MagicMock()
+        msg.data = {"uri": "no/such/sound-file-xyz.wav"}
+        with patch("ovos_audio.service.LOG") as mock_log:
+            svc.handle_instant_play(msg)
+        mock_log.warning.assert_called()
+
+    def test_handle_instant_play_no_uri_or_binary_data_logs_and_returns(self):
+        svc = self._make_minimal_service()
+        msg = MagicMock()
+        msg.data = {}
+        with patch("ovos_audio.service.LOG") as mock_log:
+            svc.handle_instant_play(msg)
+        mock_log.warning.assert_called()
+
+    def test_handle_queue_audio_unresolvable_uri_logs_and_returns(self):
+        svc = self._make_minimal_service()
+        msg = MagicMock()
+        msg.data = {"uri": "no/such/sound-file-xyz.wav"}
+        with patch("ovos_audio.service.LOG") as mock_log:
+            svc.handle_queue_audio(msg)
+        mock_log.warning.assert_called()
+
+    def test_handle_queue_audio_no_uri_or_binary_data_logs_and_returns(self):
+        svc = self._make_minimal_service()
+        msg = MagicMock()
+        msg.data = {}
+        with patch("ovos_audio.service.LOG") as mock_log:
+            svc.handle_queue_audio(msg)
+        mock_log.warning.assert_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/test/unittests/test_remaining_gaps.py
+++ b/test/unittests/test_remaining_gaps.py
@@ -228,11 +228,12 @@ class TestMaybeReloadFallbackShutdown(unittest.TestCase):
 
 class TestHandleInstantPlayNoUri(unittest.TestCase):
 
-    def test_raises_value_error_when_no_uri_or_binary_data(self):
+    def test_logs_and_returns_when_no_uri_or_binary_data(self):
         svc = _make_svc()
         msg = Message("mycroft.audio.play_sound", {})  # no uri, no binary_data
-        with self.assertRaises(ValueError):
+        with patch("ovos_audio.service.LOG") as mock_log:
             svc.handle_instant_play(msg)
+        mock_log.warning.assert_called()
 
 
 # ===========================================================================

--- a/test/unittests/test_speech.py
+++ b/test/unittests/test_speech.py
@@ -161,13 +161,15 @@ class TestSpeech(unittest.TestCase):
         bus = mock.Mock()
         speech = PlaybackService(bus=bus)
 
-        with self.assertRaises(ValueError):
+        with mock.patch("ovos_audio.service.LOG") as mock_log:
             msg = Message("", {})
             speech.handle_queue_audio(msg)
+        mock_log.warning.assert_called()
 
-        with self.assertRaises(FileNotFoundError):
+        with mock.patch("ovos_audio.service.LOG") as mock_log:
             msg = Message("", {"filename": "no_exist.mp3"})
             speech.handle_queue_audio(msg)
+        mock_log.warning.assert_called()
 
         # TODO - fix res path and reenable
         #f = f"{MYCROFT_ROOT_PATH}/mycroft/res/snd/start_listening.wav"


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Verify before acting.

Addresses the second point of #190. `handle_instant_play` and `handle_queue_audio` in `PlaybackService` are registered directly as bus event handlers. The `require_default_session()` decorator that wraps them only gates on session id — it does not catch anything — so a missing or unresolvable sound file, or a message that carries neither `uri` nor `binary_data`, propagated a `FileNotFoundError` or `ValueError` straight into pyee's `emit`. In the logs that reads as an unhandled crash ("exception calling callback for <Future ... raised FileNotFoundError>") for what is a routine, recoverable condition — a skill or client asking to play a sound that does not exist.

Both handlers now catch that condition at the point it would otherwise escape, log a warning naming the message topic and the offending uri or message data, and return without playing. `_resolve_sound_uri` itself is untouched and still raises `FileNotFoundError`, so anything calling it directly (outside the bus handlers) keeps seeing the exception.

Two pre-existing tests (`test_remaining_gaps.py::TestHandleInstantPlayNoUri`, `test_speech.py::TestSpeech::test_queue`) asserted the old raise-through behaviour for the missing-uri case; they're updated to assert the new log-and-return contract, since that behaviour is exactly what this PR intentionally changes. Four new regression tests cover both handlers against both failure modes (unresolvable uri, missing uri/binary_data) and were confirmed to fail against the unfixed handlers before the change.