### PR TITLE
fix: allow ovos-config 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 dependencies = [
     "ovos-utils>=0.8.5,<1.0.0",
     "ovos_bus_client>=2.8.3a1,<3.0.0",
-    "ovos-config>=0.0.12,<3.0.0",
+    "ovos-config>=0.0.12,<4.0.0",
     "ovos-plugin-manager>=2.10.0a1,<3.0.0",
     "ovos-spec-tools>=0.17.3a1",
 ]


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5, review and orchestration) with Claude Sonnet 5 (claude-sonnet-5, edits) via Claude Code — NOT human-reviewed. Verify before acting.

ovos-config 3.0.0a1 is a breaking release that introduces AssistantConfig and removes the remote-config APIs. An adversarial sweep of this repo found no use of any API that was removed in that release, so the `<3.0.0` upper bound on the `ovos-config` dependency only blocks a compatible upgrade without protecting against any real incompatibility.

This raises the cap to `<4.0.0`, keeping the existing floor. Normal resolution still lands on ovos-config 2.x because the PyPI release of ovos-bus-client still caps ovos-config below 3.0.0 (that cap-lift is a separate draft PR). Forcing `ovos-config==3.0.1a1` and running the suite against it gives 342 passed and 11 skipped, with 4 pre-existing failures in `test_end2end.py::TestLegacy` (an unrelated `SimpleOldAudioService.meta` AttributeError) that reproduce identically against ovos-config 2.x, confirming they are not caused by this change.

Merge after ovos-config 3.0.1a1: 3.0.0a1 is missing follow-up hardening that ships in 3.0.1a1.

An independent differential gate confirmed the failure claim: the same suite against ovos-config 3.0.1a1 and 2.3.11a2 fails on exactly the same four `TestLegacy` end-to-end cases (279 passed, 11 skipped on both), and importing the daemon under 3.0.1a1 raises nothing config-related. The companion cap lift in ovos-bus-client (2.9.1a1) is what makes this one effective: with it on PyPI, a fresh resolve of this branch picks ovos-config 3.0.1a1 and ovos-bus-client 2.9.1a1 cleanly and the daemon imports without a config-related warning. 2.x installs are untouched by the widened cap.
