### PR TITLE
docs: fix stale recognizer_loop:audio_output_*/mycroft.mic.listen topic names

### DIFF
--- a/docs/audio-service.md
+++ b/docs/audio-service.md
@@ -69,8 +69,8 @@ Track format:
 
 | Bus Event | Action |
 |---|---|
-| `recognizer_loop:audio_output_start` | Lower volume (TTS speaking) |
-| `recognizer_loop:audio_output_end` | Restore volume |
+| `ovos.audio.output.started` | Lower volume (TTS speaking) |
+| `ovos.audio.output.ended` | Restore volume |
 | `recognizer_loop:record_begin` | Lower volume (mic active) |
 | `recognizer_loop:record_end` | Restore volume (with 8 s speech-detection grace period) |
 | `ovos.utterance.handled` | Restore volume if not currently speaking |

--- a/docs/tts.md
+++ b/docs/tts.md
@@ -49,13 +49,13 @@ A daemon `Thread` that consumes entries from `TTS.queue` (a `Queue`) and plays t
 PlaybackThread.run()
   └── loop:
         dequeue entry → _play()
-            ├── on_start()         → begin_audio()  → emit recognizer_loop:audio_output_start
+            ├── on_start()         → begin_audio()  → emit ovos.audio.output.started
             ├── TTSTransformersService.transform()   (post-process wav)
             ├── emit recognizer_loop:utterance_start
             ├── play_audio(path)   (subprocess via ovos_utils.sound)
             ├── show_visemes()     (if enclosure set)
-            └── on_end(listen)     → end_audio()    → emit recognizer_loop:audio_output_end
-                                                     → emit mycroft.mic.listen  (if listen=True)
+            └── on_end(listen)     → end_audio()    → emit ovos.audio.output.ended
+                                                     → emit ovos.mic.listen  (if listen=True)
 ```
 
 ### OCP Integration
@@ -110,10 +110,10 @@ If a G2P (Grapheme-to-Phoneme) plugin is configured (`g2p.module` in `mycroft.co
 
 | Event | When |
 |---|---|
-| `recognizer_loop:audio_output_start` | Playback of a batch of queued audio begins |
-| `recognizer_loop:audio_output_end` | Playback of a batch of queued audio ends |
+| `ovos.audio.output.started` | Playback of a batch of queued audio begins |
+| `ovos.audio.output.ended` | Playback of a batch of queued audio ends |
 | `recognizer_loop:utterance_start` | Each individual utterance starts playing |
-| `mycroft.mic.listen` | After speech ends when `listen=True` |
+| `ovos.mic.listen` | After speech ends when `listen=True` |
 
 | Event | When |
 |---|---|


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Sonnet 5 (claude-sonnet-5) via Claude Code — NOT human-reviewed. Verify before acting.

`PlaybackThread.begin_audio()`/`end_audio()` emit `SpecMessage.AUDIO_OUTPUT_STARTED`/`AUDIO_OUTPUT_ENDED`/`MIC_LISTEN` (from `ovos_spec_tools`), not the `recognizer_loop:*`/`mycroft.mic.listen` literal strings the docs claimed. Resolved the enum directly (`ovos.audio.output.started`, `ovos.audio.output.ended`, `ovos.mic.listen`) and confirmed every emit site in `ovos_audio/playback.py` and `ovos_audio/audio.py` uses the same constants — no `recognizer_loop:audio_output_*` spelling exists anywhere in either file.

`recognizer_loop:utterance_start`, `recognizer_loop:record_begin`/`record_end`, and `ovos.utterance.handled` are untouched literal-string topics elsewhere in the same files, confirmed correct as documented — only the two audio-output/mic-listen topics needed fixing.

Fixed both the `PlaybackThread` lifecycle diagram and event table in `docs/tts.md`, and the ducking event table in `docs/audio-service.md`.

## Verified claims
- `from ovos_spec_tools import SpecMessage; SpecMessage.AUDIO_OUTPUT_STARTED` → `ovos.audio.output.started` (and similarly for `AUDIO_OUTPUT_ENDED`/`MIC_LISTEN`).
- Every `self.bus.emit(...)`/`self.bus.on(...)` call site in `ovos_audio/playback.py` and `ovos_audio/audio.py` grepped directly.

## Test plan
- [ ] Docs-only change, no code touched.