### PR TITLE
build: allow ovos-config 3.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ requires-python = ">=3.10"
 dependencies = [
     "ovos-utils>=0.8.5,<1.0.0",
     "ovos_bus_client>=2.8.3a1,<3.0.0",
-    "ovos-config>=0.0.12,<3.0.0",
+    "ovos-config>=0.0.12,<4.0.0",
     "ovos-plugin-manager>=2.10.0a1,<3.0.0",
     "ovos-spec-tools>=0.17.3a1",
 ]


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5.1 (claude-fable-5-1) via Claude Code — NOT human-reviewed. Verify before acting.

Widens the `ovos-config` ceiling from `<3.0.0` to `<4.0.0`. The cap is stale: ovos-config 3.0.0 is a single breaking commit (5a7d1a3, "feat!: drop remote config") that removed `MycroftDefaultConfig`, `MycroftSystemConfig`, `MycroftUserConfig`, `OvosDistributionConfig`, `USER_CONFIG`, `WEB_CONFIG_CACHE` and the CLI `show()`. A `git grep` for those names on dev returns nothing, so none of the removed surface is used here.

Install proof: a clean venv with `-e .` plus `ovos-config>=3.5.0a1` resolves to ovos-config 3.5.0a1 with no downgrade.