### PR TITLE
fix: read each transformer stage's own config section

### DIFF
--- a/ovos_audio/transformers.py
+++ b/ovos_audio/transformers.py
@@ -8,13 +8,32 @@ from ovos_plugin_manager.transformer_services import (
 from ovos_plugin_manager.tts_transformers import find_tts_transformer_plugins
 
 
+def _stage_config(config: Optional[dict], section: str) -> dict:
+    """The configuration for one transformer stage.
+
+    The plugin manager accepts either a whole core configuration or the
+    stage's own section, and cannot tell them apart when the whole
+    configuration does not carry the section: every top-level key then reads
+    as an enabled plugin, and the loader warns once per key that the plugin
+    is not installed. Neither of this module's sections ships in the default
+    configuration, so reading the section here is what keeps an ordinary
+    boot quiet.
+
+    An explicit ``config`` is returned untouched, because a caller that
+    supplies one has already named the mapping it wants used.
+    """
+    if config is not None:
+        return config
+    return Configuration().get(section) or {}
+
+
 class DialogTransformersService(_DialogTransformersService):
     """Transforms dialogs before being sent to TTS, in OVOS-TRANSFORM §4
     ascending priority order: a plugin of priority 1 runs first."""
 
     def __init__(self, bus, config: Optional[dict] = None):
-        config = config or Configuration()
-        super().__init__(bus=bus, config=config)
+        super().__init__(bus=bus,
+                         config=_stage_config(config, self.config_section))
 
     @classmethod
     def find_plugins(cls):
@@ -26,8 +45,8 @@ class TTSTransformersService(_TTSTransformersService):
     priority order: a plugin of priority 1 runs first."""
 
     def __init__(self, bus=None, config: Optional[dict] = None):
-        config = config or Configuration()
-        super().__init__(bus=bus, config=config)
+        super().__init__(bus=bus,
+                         config=_stage_config(config, self.config_section))
 
     @classmethod
     def find_plugins(cls):

--- a/test/unittests/test_transformers.py
+++ b/test/unittests/test_transformers.py
@@ -242,3 +242,67 @@ class TestTTSTransformersService(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestStageConfigResolution(unittest.TestCase):
+    """A stage reads its own config section.
+
+    Neither ``dialog_transformers`` nor ``tts_transformers`` ships in the
+    default configuration, and the plugin manager cannot tell a whole core
+    configuration lacking the section from the section itself: every
+    top-level key then reads as an enabled plugin and the loader warns once
+    per key. That made an ordinary boot log dozens of false lines.
+    """
+
+    FULL_CONFIG = {
+        "lang": "en-US",
+        "listener": {"sample_rate": 16000},
+        "websocket": {"host": "127.0.0.1"},
+        "tts": {"module": "ovos-tts-plugin-server"},
+        "date_format": "DMY",
+        "system_unit": "metric",
+    }
+
+    def _services(self):
+        from ovos_audio.transformers import (DialogTransformersService,
+                                             TTSTransformersService)
+        return (("ovos_audio.transformers.find_dialog_transformer_plugins",
+                 DialogTransformersService),
+                ("ovos_audio.transformers.find_tts_transformer_plugins",
+                 TTSTransformersService))
+
+    def _warnings(self, finder, cls, config=None, full=None):
+        with patch(finder, return_value={}), \
+             patch("ovos_audio.transformers.Configuration",
+                   return_value=dict(full if full is not None
+                                     else self.FULL_CONFIG)), \
+             patch("ovos_plugin_manager.transformer_services.LOG.warning") as w:
+            svc = cls(bus=MagicMock(), config=config)
+        return svc, [c.args[0] for c in w.call_args_list]
+
+    def test_a_boot_warns_about_nothing(self):
+        for finder, cls in self._services():
+            with self.subTest(service=cls.__name__):
+                _, warnings = self._warnings(finder, cls)
+                self.assertEqual(
+                    warnings, [],
+                    f"{cls.__name__} read top-level config keys as plugins: "
+                    f"{warnings}")
+
+    def test_a_configured_but_missing_plugin_is_still_reported(self):
+        """The guard that silencing the false lines kept the true one."""
+        finder, cls = self._services()[0]
+        full = dict(self.FULL_CONFIG)
+        full["dialog_transformers"] = {"some-dialog-plugin": {}}
+        _, warnings = self._warnings(finder, cls, full=full)
+        self.assertEqual(len(warnings), 1, warnings)
+        self.assertIn("some-dialog-plugin", warnings[0])
+
+    def test_an_explicit_config_is_passed_through_untouched(self):
+        """A caller that supplies a mapping has named what it wants used."""
+        finder, cls = self._services()[0]
+        section = {"some-dialog-plugin": {"active": True}}
+        svc, warnings = self._warnings(finder, cls, config=section)
+        self.assertEqual(svc.config, section)
+        self.assertEqual(len(warnings), 1, warnings)
+        self.assertIn("some-dialog-plugin", warnings[0])


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Opus 5 (claude-opus-5) via Claude Code — NOT human-reviewed. Every number below was executed, not remembered.

Every boot of `ovos-audio` logs **68 spurious WARNING lines**, one per top-level `mycroft.conf` key per stage, claiming each is an enabled transformer plugin that is not installed.

```
'date_format' is enabled in the 'dialog_transformers' config section but is not installed
'system_unit' is enabled in the 'dialog_transformers' config section but is not installed
'date_format' is enabled in the 'tts_transformers' config section but is not installed
...
```

## Cause

`TransformersService._resolve_section` accepts either a whole core configuration or the stage's own section, and cannot tell them apart when the whole configuration does not carry the section:

```python
if cls.config_section and cls.config_section in config:
    return dict(config.get(cls.config_section) or {})
return dict(config)          # <- the whole mycroft.conf becomes "the section"
```

Both services here passed `Configuration()`, and **neither `dialog_transformers` nor `tts_transformers` ships in the default configuration**, so the fallback is taken on an ordinary device rather than in an edge case.

That holds at every vintage, not only the one measured: `git log -S` over `ovos_config/mycroft.conf` shows neither section has ever been added, including at `3.5.0a1`. So unlike `typed_slots_transformers` in OpenVoiceOS/ovos-core#965, which storms only below the release that added it, these two storm on every version of `ovos-config` there has been.

Measured on a stock config, one construction per stage exactly as `service.py:95` and `playback.py:35` build them:

| Stage | Before | After |
| --- | --- | --- |
| `DialogTransformersService` | 34 | 0 |
| `TTSTransformersService` | 34 | 0 |

## The change

Each stage reads its own section when it configures itself from the deployment, so the ambiguous path is never taken. An explicit `config` argument is passed through untouched, because a caller that supplies one has already named the mapping it wants used, and this repo's own tests rely on that.

Same fix as OpenVoiceOS/ovos-core#965, which covers that repo's four stages.

## What is deliberately still noisy

A plugin that really is configured and really is absent still warns, once. One of the new tests is the guard that silencing the false lines did not silence the true one.

## Verification

| Run | Result |
| --- | --- |
| fail-before: `dev` source with the new tests | 2 failed, 28 passed |
| after | 28 passed, 2 subtests |
| full `test/unittests` | 282 passed, 11 skipped, 4 failed |

The third new test passes before and after by design: it is the guard that an explicit config still reaches the service unchanged.

The 4 suite failures are `test_end2end.py::TestLegacy`, which fail identically on `dev` and are unrelated to this change: `SimpleOldAudioService` inherits a v2 `load_track` that reads state its constructor never creates. Reported as #200.

