### PR TITLE
fix: drive TestLegacy with the purpose-built legacy plugin

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -35,7 +35,7 @@ test = [
     "pytest>=5.2.4",
     "pytest-cov>=2.8.1",
     "cov-core>=1.15.0",
-    "ovos-media-plugin-simple>=0.1.0a1, <1.0.0",
+    "ovos-audio-plugin-simple>=0.1.4a3, <1.0.0",
 ]
 extras = [
     "ovos-dialog-normalizer-plugin>=0.0.3a1, <1.0.0",

--- a/test/unittests/test_end2end.py
+++ b/test/unittests/test_end2end.py
@@ -26,12 +26,12 @@ from ovos_bus_client.session import SessionManager, Session
 def _simple_plugin_available() -> bool:
     try:
         from ovos_plugin_manager.audio import find_audio_service_plugins
-        return "ovos_simple" in find_audio_service_plugins()
+        return "ovos_audio_simple" in find_audio_service_plugins()
     except Exception:
         return False
 
 
-@unittest.skipUnless(_simple_plugin_available(), "ovos_simple audio plugin not installed")
+@unittest.skipUnless(_simple_plugin_available(), "ovos_audio_simple plugin not installed")
 class TestLegacy(unittest.TestCase):
     def setUp(self):
         self.core = AudioService(FakeBus(), disable_ocp=True,
@@ -39,7 +39,7 @@ class TestLegacy(unittest.TestCase):
                                  validate_source=True)
         self.core.config['default-backend'] = "simple"
         self.core.config['backends'] = {"simple": {
-            "type": "ovos_simple",
+            "type": "ovos_audio_simple",
             "active": True
         }}
         self.core.load_services()


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

`TestLegacy` was red or green depending on entry-point iteration order: two installed plugins each register a service named "simple", and the suite's outcome depended on which loaded first (executed evidence: identical tree and versions pass on one python build and fail 4/6 on another, tracked to load order; in CI only the shim installs, so the red is deterministic there). The test's exact-sequence assertions only work when the plugin's playback machinery is disconnected, which the legacy `ovos-audio-plugin-simple` self-command design offers and the dual-target media shim structurally cannot.

The `[test]` extra now installs the legacy plugin, and `TestLegacy` addresses its `ovos_audio_simple` entry point; wire topics are unchanged (they key off the config name "simple"). Runtime `extras` keep the media-plugin defaults untouched. Full suite on the branch: 346 passed, 0 failed, 11 skipped (the skips are pre-existing `@unittest.skip` decorators).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
