### PR TITLE
fix: point the extras at the renamed media plugin package

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,10 +43,11 @@ extras = [
     "phoonnx>=0.5.4, <1.0.0",
     # media plugins supersede the deprecated ovos-audio-plugin-* backends and
     # expose compatible endpoints: simple + mpv replace the old simple/mpv local
-    # playback. ovos-media-plugin-vlc is intentionally NOT a default — its libvlc
+    # playback; the simple backend ships in the cli package after its repo
+    # rename. ovos-media-plugin-vlc is intentionally NOT a default — its libvlc
     # binding is (L)GPL, outside the permissive-by-default policy; users opt in
     # explicitly (pip install ovos-media-plugin-vlc).
-    "ovos-media-plugin-simple>=0.1.0a1, <1.0.0",
+    "ovos-media-plugin-cli>=0.0.6a1, <1.0.0",
     "ovos-media-plugin-mpv>=1.0.0a2, <2.0.0",
     "ovos-media-plugin-spotify>=0.2.8a5, <1.0.0",
     "ovos-media-plugin-chromecast>=0.1.4a8, <1.0.0",


### PR DESCRIPTION
> 🤖 Auto-generated by Claude Fable 5 (claude-fable-5) via Claude Code — NOT human-reviewed. Verify before acting.

## What changed
The `extras` group's `ovos-media-plugin-simple>=0.1.0a1` pin becomes `ovos-media-plugin-cli>=0.0.6a1`. One line plus a comment note.

## Why
The `ovos-media-plugin-simple` package on PyPI is orphaned: its repo was renamed to `ovos-media-plugin-cli` (commit 96a6525), and the frozen 0.1.0a1 wheel still carries the broken legacy adapter (the `meta` AttributeError plus the lifecycle defects fixed in ovos-media-plugin-cli#8/#10). 0.0.6a1 is the first cli release with all of those fixes, hence the floor.

## Evidence
- `uv pip install -e .[extras]` resolves; `import ovos_media_plugin_cli` succeeds in the fresh venv.
- Full test tree with `[extras]` + `[test]` both installed (so both a "simple"-named provider and the cli plugin are present): 349 passed, 11 pre-existing skips, 0 failures on dev.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
